### PR TITLE
Add GitHub action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,42 @@
+name: Go Test
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [ '1.23', '1.24' ]
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up Go ${{ matrix.go-version }}
+      uses: actions/setup-go@v4
+      with:
+        go-version: ${{ matrix.go-version }}
+
+    - name: Get dependencies
+      run: go mod download
+
+    - name: Verify dependencies
+      run: go mod verify
+
+    - name: Format check
+      run: |
+        if [ "$(gofmt -s -l . | wc -l)" -gt 0 ]; then
+          echo "Please run 'gofmt -s -w .' to format your code."
+          gofmt -s -l .
+          exit 1
+        fi
+
+    - name: Vet
+      run: go vet ./...
+
+    - name: Test
+      run: go test `find . -name "*_test.go" -print0 | xargs -0 -n1 dirname | sort -u`

--- a/ast/ast_test.go
+++ b/ast/ast_test.go
@@ -1,7 +1,0 @@
-package ast
-
-import (
-	"monkey/token"
-	"testing"
-)
-


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for running Go tests and removes some unused imports from a test file.

New GitHub Actions workflow:

* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R1-R42): Added a workflow to run Go tests on pull requests targeting the `main` branch. The workflow includes steps for checking out the code, setting up Go, downloading and verifying dependencies, checking code formatting, running `go vet`, and executing tests.

Code cleanup:

* [`ast/ast_test.go`](diffhunk://#diff-992106e5e5345d435eef5f6b2f37d1a4f8997d93727df260032eb201bf4efd14L1-L7): Removed unused imports from the test file to clean up the code.