### PR TITLE
Add variable

### DIFF
--- a/code/code.go
+++ b/code/code.go
@@ -32,6 +32,8 @@ const (
 	OpJump
 	OpJumpNotTruthy
 	OpNull
+	OpSetGlobal
+	OpGetGlobal
 )
 
 var definitions = map[Opcode]*Definition{
@@ -51,6 +53,8 @@ var definitions = map[Opcode]*Definition{
 	OpJump:          {"OpJump", []int{2}},
 	OpJumpNotTruthy: {"OpJumpNotTruthy", []int{2}},
 	OpNull:          {"OpNull", []int{}},
+	OpGetGlobal:     {"OpGetGlobal", []int{2}},
+	OpSetGlobal:     {"OpSetGlobal", []int{2}},
 }
 
 func Lookup(op byte) (*Definition, error) {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -32,6 +32,13 @@ func New() *Compiler {
 	}
 }
 
+func NewWithState(s *SymbolTable, constants []object.Object) *Compiler {
+	compiler := New()
+	compiler.symbolTable = s
+	compiler.constants = constants
+	return compiler
+}
+
 func (c *Compiler) Compile(node ast.Node) error {
 	switch node := node.(type) {
 	case *ast.Program:

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -18,6 +18,8 @@ type Compiler struct {
 
 	lastInstruction     EmittedInstruction
 	previousInstruction EmittedInstruction
+
+	symbolTable *SymbolTable
 }
 
 func New() *Compiler {
@@ -26,6 +28,7 @@ func New() *Compiler {
 		constants:           []object.Object{},
 		lastInstruction:     EmittedInstruction{},
 		previousInstruction: EmittedInstruction{},
+		symbolTable:         NewSymbolTable(),
 	}
 }
 
@@ -148,6 +151,19 @@ func (c *Compiler) Compile(node ast.Node) error {
 				return err
 			}
 		}
+	case *ast.LetStatement:
+		err := c.Compile(node.Value)
+		if err != nil {
+			return err
+		}
+		symbol := c.symbolTable.Define(node.Name.Value)
+		c.emit(code.OpSetGlobal, symbol.Index)
+	case *ast.Identifier:
+		symbol, ok := c.symbolTable.Resolve(node.Value)
+		if !ok {
+			return fmt.Errorf("undefined variable %s", node.Value)
+		}
+		c.emit(code.OpGetGlobal, symbol.Index)
 	}
 	return nil
 }

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -227,6 +227,69 @@ func TestConditionals(t *testing.T) {
 	runCompilerTests(t, tests)
 }
 
+func TestGlobalLetStatements(t *testing.T) {
+	tests := []compilerTestCase{
+		{
+			input: `
+let one = 1;
+let two = 2;
+`,
+			expectedConstants: []interface{}{1, 2},
+			expectedInstructions: []code.Instructions{
+				// 0000
+				code.Make(code.OpConstant, 0),
+				// 0003
+				code.Make(code.OpSetGlobal, 0),
+				// 0006
+				code.Make(code.OpConstant, 1),
+				// 0009
+				code.Make(code.OpSetGlobal, 1),
+			},
+		},
+		{
+			input: `
+let one = 1;
+one;
+`,
+			expectedConstants: []interface{}{1},
+			expectedInstructions: []code.Instructions{
+				// 0000
+				code.Make(code.OpConstant, 0),
+				// 0003
+				code.Make(code.OpSetGlobal, 0),
+				// 0006
+				code.Make(code.OpGetGlobal, 0),
+				// 0009
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input: `
+			let one = 1;
+			let two = one;
+			two;
+			`,
+			expectedConstants: []interface{}{1},
+			expectedInstructions: []code.Instructions{
+				// 0000
+				code.Make(code.OpConstant, 0),
+				// 0003
+				code.Make(code.OpSetGlobal, 0),
+				// 0006
+				code.Make(code.OpGetGlobal, 0),
+				// 0009
+				code.Make(code.OpSetGlobal, 1),
+				// 0012
+				code.Make(code.OpGetGlobal, 1),
+				// 0015
+				code.Make(code.OpPop),
+			},
+		},
+	}
+
+	runCompilerTests(t, tests)
+}
+
 func runCompilerTests(t *testing.T, tests []compilerTestCase) {
 	t.Helper()
 

--- a/compiler/symbol_table.go
+++ b/compiler/symbol_table.go
@@ -1,0 +1,35 @@
+package compiler
+
+type SymbolScope string
+
+const (
+	GlobalScope SymbolScope = "GLOBAL"
+)
+
+type Symbol struct {
+	Name  string
+	Scope SymbolScope
+	Index int
+}
+
+type SymbolTable struct {
+	store          map[string]Symbol
+	numDefinitions int
+}
+
+func NewSymbolTable() *SymbolTable {
+	s := make(map[string]Symbol)
+	return &SymbolTable{store: s}
+}
+
+func (s *SymbolTable) Define(name string) Symbol {
+	symbol := Symbol{Name: name, Index: s.numDefinitions, Scope: GlobalScope}
+	s.store[name] = symbol
+	s.numDefinitions++
+	return symbol
+}
+
+func (s *SymbolTable) Resolve(name string) (Symbol, bool) {
+	obj, ok := s.store[name]
+	return obj, ok
+}

--- a/compiler/symbol_table_test.go
+++ b/compiler/symbol_table_test.go
@@ -1,0 +1,40 @@
+package compiler
+
+import "testing"
+
+func TestDefine(t *testing.T) {
+	expected := map[string]Symbol{
+		"a": {Name: "a", Scope: GlobalScope, Index: 0},
+		"b": {Name: "b", Scope: GlobalScope, Index: 1},
+	}
+	global := NewSymbolTable()
+	a := global.Define("a")
+	if a != expected["a"] {
+		t.Errorf("expected a=%+v, got=%+v", expected["a"], a)
+	}
+	b := global.Define("b")
+	if b != expected["b"] {
+		t.Errorf("expected b=%+v, got=%+v", expected["b"], b)
+	}
+}
+
+func TestResolveGlobal(t *testing.T) {
+	global := NewSymbolTable()
+	global.Define("a")
+	global.Define("b")
+	expected := []Symbol{
+		{Name: "a", Scope: GlobalScope, Index: 0},
+		{Name: "b", Scope: GlobalScope, Index: 1},
+	}
+	for _, sym := range expected {
+		result, ok := global.Resolve(sym.Name)
+		if !ok {
+			t.Errorf("name %s not resolvable", sym.Name)
+			continue
+		}
+		if result != sym {
+			t.Errorf("expected %s to resolve to %+v, got=%+v",
+				sym.Name, sym, result)
+		}
+	}
+}

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -8,6 +8,7 @@ import (
 )
 
 const StackSize = 2048
+const GlobalsSize = 65536
 
 var True = &object.Boolean{Value: true}
 var False = &object.Boolean{Value: false}
@@ -17,8 +18,9 @@ type VM struct {
 	constants    []object.Object
 	instructions code.Instructions
 
-	stack []object.Object
-	sp    int
+	stack  []object.Object
+	sp     int
+	globals []object.Object
 }
 
 func New(bytecode *compiler.Bytecode) *VM {
@@ -26,9 +28,16 @@ func New(bytecode *compiler.Bytecode) *VM {
 		constants:    bytecode.Constants,
 		instructions: bytecode.Instructions,
 
-		stack: make([]object.Object, StackSize),
-		sp:    0,
+		stack:  make([]object.Object, StackSize),
+		sp:     0,
+		globals: make([]object.Object, GlobalsSize),
 	}
+}
+
+func NewWithGlobalsStore(bytecode *compiler.Bytecode, s []object.Object) *VM {
+	vm := New(bytecode)
+	vm.globals = s
+	return vm
 }
 
 func (vm *VM) StackTop() object.Object {
@@ -92,6 +101,17 @@ func (vm *VM) Run() error {
 			}
 		case code.OpNull:
 			err := vm.push(Null)
+			if err != nil {
+				return err
+			}
+		case code.OpSetGlobal:
+			globalIndex := code.ReadUint16(vm.instructions[ip+1:])
+			ip += 2
+			vm.globals[globalIndex] = vm.pop()
+		case code.OpGetGlobal:
+			globalIndex := code.ReadUint16(vm.instructions[ip+1:])
+			ip += 2
+			err := vm.push(vm.globals[globalIndex])
 			if err != nil {
 				return err
 			}

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -111,6 +111,15 @@ func TestConditionals(t *testing.T) {
 	runVmTests(t, tests)
 }
 
+func TestGlobalLetStatements(t *testing.T) {
+	tests := []vmTestCase{
+		{"let one = 1; one;", 1},
+		{"let one = 1; let two = 2; one + two;", 3},
+		{"let one = 1; let two = one + one; one + two;", 3},
+	}
+	runVmTests(t, tests)
+}
+
 func parse(input string) *ast.Program {
 	l := lexer.New(input)
 	p := parser.New(l)


### PR DESCRIPTION
This pull request introduces several significant changes to the compiler and virtual machine (VM) to support global variables. The most important changes include adding new opcodes, modifying the compiler to handle global variables, and updating the VM to support global variable operations.

### Compiler Enhancements:
* Added `OpSetGlobal` and `OpGetGlobal` opcodes to the `Opcode` enumeration and their definitions in the `definitions` map in `code/code.go`. [[1]](diffhunk://#diff-2ad350013d16e8e5c021ee6f046700bb0b8249a3baa1fe88c79aac3c06c214bbR35-R36) [[2]](diffhunk://#diff-2ad350013d16e8e5c021ee6f046700bb0b8249a3baa1fe88c79aac3c06c214bbR56-R57)
* Updated the `Compiler` struct to include a `symbolTable` and added a new constructor `NewWithState` to initialize the compiler with an existing symbol table and constants in `compiler/compiler.go`. [[1]](diffhunk://#diff-d3cde2dec4b7c2263747b17d43f704418e6657b49583254628bcad1d1052471bR21-R22) [[2]](diffhunk://#diff-d3cde2dec4b7c2263747b17d43f704418e6657b49583254628bcad1d1052471bR31-R39)
* Modified the `Compile` method in `compiler/compiler.go` to handle `LetStatement` and `Identifier` nodes, emitting the appropriate global variable opcodes.
* Introduced a `SymbolTable` to manage symbol definitions and resolution in `compiler/symbol_table.go`.

### Virtual Machine Enhancements:
* Added support for `OpSetGlobal` and `OpGetGlobal` opcodes in the VM, including a `globals` array to store global variables in `vm/vm.go`. [[1]](diffhunk://#diff-c087fa7dffa5d472e6b7b59eb8f8bafd4208832487a1429e0fcfc38a9fe05167R11) [[2]](diffhunk://#diff-c087fa7dffa5d472e6b7b59eb8f8bafd4208832487a1429e0fcfc38a9fe05167R23) [[3]](diffhunk://#diff-c087fa7dffa5d472e6b7b59eb8f8bafd4208832487a1429e0fcfc38a9fe05167R33-R42) [[4]](diffhunk://#diff-c087fa7dffa5d472e6b7b59eb8f8bafd4208832487a1429e0fcfc38a9fe05167R107-R117)
* Updated the REPL to maintain the state of global variables across multiple executions by using the new `NewWithState` method for the compiler and VM in `repl/repl.go`. [[1]](diffhunk://#diff-f3738eaa02e99234edda29447e81abd0c95e16bed33ee6a499379d8b34219373R11) [[2]](diffhunk://#diff-f3738eaa02e99234edda29447e81abd0c95e16bed33ee6a499379d8b34219373R22-R24) [[3]](diffhunk://#diff-f3738eaa02e99234edda29447e81abd0c95e16bed33ee6a499379d8b34219373L53-R65)

### Tests:
* Added tests for defining and resolving global symbols in `compiler/symbol_table_test.go`.
* Added compiler tests for global `let` statements in `compiler/compiler_test.go`.
* Added VM tests for global `let` statements in `vm/vm_test.go`.