### PR TITLE
feat: add push trigger for Go Test workflow on main branch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,8 @@ name: Go Test
 on:
   pull_request:
     branches: [ main ]
+  push:
+    branches: [ main ]
 
 jobs:
   test:


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/test.yml` file. The change adds a new trigger for the workflow to run on pushes to the `main` branch. 

* [`.github/workflows/test.yml`](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88R6-R7): Added a `push` trigger to run the workflow on pushes to the `main` branch.