### PR TITLE
docs: fix reference in README.md for "Writing A Compiler In Go"

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,4 +101,4 @@ go test ./lexer
 ## References
 
 - "Writing An Interpreter In Go" by Thorsten Ball
-- "Writing A Compiler In Go" by Thorsten Ball Monkey
+- "Writing A Compiler In Go" by Thorsten Ball


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change corrects the title of a book reference by removing an extraneous word.