### PR TITLE
Simple functions

### DIFF
--- a/code/code.go
+++ b/code/code.go
@@ -37,6 +37,9 @@ const (
 	OpArray
 	OpHash
 	OpIndex
+	OpCall
+	OpReturnValue
+	OpReturn
 )
 
 var definitions = map[Opcode]*Definition{
@@ -61,6 +64,9 @@ var definitions = map[Opcode]*Definition{
 	OpArray:         {"OpArray", []int{2}},
 	OpHash:          {"OpHash", []int{2}},
 	OpIndex:         {"OpIndex", []int{}},
+	OpCall:          {"OpCall", []int{}},
+	OpReturnValue:   {"OpReturnValue", []int{}},
+	OpReturn:        {"OpReturn", []int{}},
 }
 
 func Lookup(op byte) (*Definition, error) {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -14,7 +14,7 @@ type EmittedInstruction struct {
 }
 
 type Compiler struct {
-	constants    []object.Object
+	constants []object.Object
 
 	symbolTable *SymbolTable
 
@@ -36,7 +36,7 @@ func New() *Compiler {
 	}
 
 	return &Compiler{
-		constants:    []object.Object{},
+		constants:   []object.Object{},
 		symbolTable: NewSymbolTable(),
 		scopes:      []CompilationScope{mainScope},
 	}
@@ -231,10 +231,10 @@ func (c *Compiler) Compile(node ast.Node) error {
 
 		if c.lastInstructionIs(code.OpPop) {
 			c.replaceLastPopWithReturn()
-			}
-			if !c.lastInstructionIs(code.OpReturnValue) {
+		}
+		if !c.lastInstructionIs(code.OpReturnValue) {
 			c.emit(code.OpReturn)
-			}
+		}
 
 		instructions := c.leaveScope()
 		compiledFn := &object.CompiledFunction{Instructions: instructions}
@@ -245,6 +245,12 @@ func (c *Compiler) Compile(node ast.Node) error {
 			return err
 		}
 		c.emit(code.OpReturnValue)
+	case *ast.CallExpression:
+		err := c.Compile(node.Function)
+		if err != nil {
+			return err
+		}
+		c.emit(code.OpCall)
 	}
 	return nil
 }

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -14,22 +14,31 @@ type EmittedInstruction struct {
 }
 
 type Compiler struct {
-	instructions code.Instructions
 	constants    []object.Object
 
+	symbolTable *SymbolTable
+
+	scopes     []CompilationScope
+	scopeIndex int
+}
+
+type CompilationScope struct {
+	instructions        code.Instructions
 	lastInstruction     EmittedInstruction
 	previousInstruction EmittedInstruction
-
-	symbolTable *SymbolTable
 }
 
 func New() *Compiler {
-	return &Compiler{
+	mainScope := CompilationScope{
 		instructions:        code.Instructions{},
-		constants:           []object.Object{},
 		lastInstruction:     EmittedInstruction{},
 		previousInstruction: EmittedInstruction{},
-		symbolTable:         NewSymbolTable(),
+	}
+
+	return &Compiler{
+		constants:    []object.Object{},
+		symbolTable: NewSymbolTable(),
+		scopes:      []CompilationScope{mainScope},
 	}
 }
 
@@ -134,7 +143,7 @@ func (c *Compiler) Compile(node ast.Node) error {
 
 		// Emit an `OpJump` with a bogus value
 		jumpPos := c.emit(code.OpJump, 9999)
-		afterConsequencePos := len(c.instructions)
+		afterConsequencePos := len(c.currentInstructions())
 		c.changeOperand(jumpNotTruthyPos, afterConsequencePos)
 
 		if node.Alternative == nil {
@@ -150,7 +159,7 @@ func (c *Compiler) Compile(node ast.Node) error {
 			}
 		}
 
-		afterAlternativePos := len(c.instructions)
+		afterAlternativePos := len(c.currentInstructions())
 		c.changeOperand(jumpPos, afterAlternativePos)
 	case *ast.BlockStatement:
 		for _, s := range node.Statements {
@@ -213,6 +222,22 @@ func (c *Compiler) Compile(node ast.Node) error {
 			return err
 		}
 		c.emit(code.OpIndex)
+	case *ast.FunctionLiteral:
+		c.enterScope()
+		err := c.Compile(node.Body)
+		if err != nil {
+			return err
+		}
+
+		instructions := c.leaveScope()
+		compiledFn := &object.CompiledFunction{Instructions: instructions}
+		c.emit(code.OpConstant, c.addConstant(compiledFn))
+	case *ast.ReturnStatement:
+		err := c.Compile(node.ReturnValue)
+		if err != nil {
+			return err
+		}
+		c.emit(code.OpReturnValue)
 	}
 	return nil
 }
@@ -224,7 +249,7 @@ type Bytecode struct {
 
 func (c *Compiler) Bytecode() *Bytecode {
 	return &Bytecode{
-		Instructions: c.instructions,
+		Instructions: c.currentInstructions(),
 		Constants:    c.constants,
 	}
 }
@@ -242,37 +267,69 @@ func (c *Compiler) emit(op code.Opcode, operands ...int) int {
 	return position
 }
 
+func (c *Compiler) currentInstructions() code.Instructions {
+	return c.scopes[c.scopeIndex].instructions
+}
+
 func (c *Compiler) addInstruction(instruction []byte) int {
-	posNewInstruction := len(c.instructions)
-	c.instructions = append(c.instructions, instruction...)
+	posNewInstruction := len(c.currentInstructions())
+	updatedInstructions := append(c.currentInstructions(), instruction...)
+	c.scopes[c.scopeIndex].instructions = updatedInstructions
 	return posNewInstruction
 }
 
 func (c *Compiler) setLastInstruction(op code.Opcode, position int) {
-	previous := c.lastInstruction
+	previous := c.scopes[c.scopeIndex].lastInstruction
 	last := EmittedInstruction{Opcode: op, Position: position}
-
-	c.previousInstruction = previous
-	c.lastInstruction = last
+	c.scopes[c.scopeIndex].previousInstruction = previous
+	c.scopes[c.scopeIndex].lastInstruction = last
 }
 
 func (c *Compiler) lastInstructionIsPop() bool {
-	return c.lastInstruction.Opcode == code.OpPop
+	return c.scopes[c.scopeIndex].lastInstruction.Opcode == code.OpPop
 }
 
 func (c *Compiler) removeLastPop() {
-	c.instructions = c.instructions[:c.lastInstruction.Position]
-	c.lastInstruction = c.previousInstruction
+	last := c.scopes[c.scopeIndex].lastInstruction
+	previous := c.scopes[c.scopeIndex].previousInstruction
+	old := c.currentInstructions()
+	new := old[:last.Position]
+	c.scopes[c.scopeIndex].instructions = new
+	c.scopes[c.scopeIndex].lastInstruction = previous
 }
 
 func (c *Compiler) replaceInstruction(pos int, newInstruction []byte) {
+	ins := c.currentInstructions()
 	for i := 0; i < len(newInstruction); i++ {
-		c.instructions[pos+i] = newInstruction[i]
+		ins[pos+i] = newInstruction[i]
 	}
 }
 
 func (c *Compiler) changeOperand(opPos int, operand int) {
-	op := code.Opcode(c.instructions[opPos])
+	op := code.Opcode(c.currentInstructions()[opPos])
 	newInstruction := code.Make(op, operand)
 	c.replaceInstruction(opPos, newInstruction)
+}
+
+func (c *Compiler) enterScope() {
+	scope := CompilationScope{
+		instructions:        code.Instructions{},
+		lastInstruction:     EmittedInstruction{},
+		previousInstruction: EmittedInstruction{},
+	}
+	c.scopes = append(c.scopes, scope)
+	c.scopeIndex++
+}
+
+func (c *Compiler) leaveScope() code.Instructions {
+	instructions := c.currentInstructions()
+	c.scopes = c.scopes[:len(c.scopes)-1]
+	c.scopeIndex--
+	return instructions
+}
+
+func (c *Compiler) replaceLastPopWithReturn() {
+	lastPos := c.scopes[c.scopeIndex].lastInstruction.Position
+	c.replaceInstruction(lastPos, code.Make(code.OpReturnValue))
+	c.scopes[c.scopeIndex].lastInstruction.Opcode = code.OpReturnValue
 }

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -229,6 +229,13 @@ func (c *Compiler) Compile(node ast.Node) error {
 			return err
 		}
 
+		if c.lastInstructionIs(code.OpPop) {
+			c.replaceLastPopWithReturn()
+			}
+			if !c.lastInstructionIs(code.OpReturnValue) {
+			c.emit(code.OpReturn)
+			}
+
 		instructions := c.leaveScope()
 		compiledFn := &object.CompiledFunction{Instructions: instructions}
 		c.emit(code.OpConstant, c.addConstant(compiledFn))
@@ -332,4 +339,8 @@ func (c *Compiler) replaceLastPopWithReturn() {
 	lastPos := c.scopes[c.scopeIndex].lastInstruction.Position
 	c.replaceInstruction(lastPos, code.Make(code.OpReturnValue))
 	c.scopes[c.scopeIndex].lastInstruction.Opcode = code.OpReturnValue
+}
+
+func (c *Compiler) lastInstructionIs(op code.Opcode) bool {
+	return c.scopes[c.scopeIndex].lastInstruction.Opcode == op
 }

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -439,45 +439,29 @@ func TestIndexExpressions(t *testing.T) {
 	runCompilerTests(t, tests)
 }
 
-func TestFunctions(t *testing.T) {
-	tests := []compilerTestCase{
-		{
-			input:             "fn() { return 5 + 10; }",
-			expectedConstants: []interface{}{5, 10},
-			expectedInstructions: []code.Instructions{
-				code.Make(code.OpConstant, 0),
-				code.Make(code.OpConstant, 1),
-				code.Make(code.OpAdd),
-				code.Make(code.OpReturnValue),
-				code.Make(code.OpPop),
-			},
-		},
-		{
-			input:             "fn() { 5 + 10; }",
-			expectedConstants: []interface{}{5, 10},
-			expectedInstructions: []code.Instructions{
-				code.Make(code.OpConstant, 0),
-				code.Make(code.OpConstant, 1),
-				code.Make(code.OpAdd),
-				code.Make(code.OpReturnValue),
-				code.Make(code.OpPop),
-			},
-		},
-		{
-			input:             "fn() { 1; 2 }",
-			expectedConstants: []interface{}{1, 2},
-			expectedInstructions: []code.Instructions{
-				code.Make(code.OpConstant, 0),
-				code.Make(code.OpPop),
-				code.Make(code.OpConstant, 1),
-				code.Make(code.OpReturnValue),
-				code.Make(code.OpPop),
-			},
-		},
-	}
+// func TestFunctions(t *testing.T) {
+// 	tests := []compilerTestCase{
+// 		{
+// 			input: `fn() { return 5 + 10 }`,
+// 			expectedConstants: []interface{}{
+// 				5,
+// 				10,
+// 				[]code.Instructions{
+// 					code.Make(code.OpConstant, 0),
+// 					code.Make(code.OpConstant, 1),
+// 					code.Make(code.OpAdd),
+// 					code.Make(code.OpReturnValue),
+// 				},
+// 			},
+// 			expectedInstructions: []code.Instructions{
+// 				code.Make(code.OpConstant, 2),
+// 				code.Make(code.OpPop),
+// 			},
+// 		},
+// 	}
 
-	runCompilerTests(t, tests)
-}
+// 	runCompilerTests(t, tests)
+// }
 
 func TestCompilerScopes(t *testing.T) {
 	compiler := New()

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -505,6 +505,25 @@ func TestCompilerScopes(t *testing.T) {
 	}
 }
 
+func TestFunctionsWithoutReturnValue(t *testing.T) {
+	tests := []compilerTestCase{
+		{
+			input: `fn() { }`,
+			expectedConstants: []interface{}{
+				[]code.Instructions{
+					code.Make(code.OpReturn),
+				},
+			},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpPop),
+			},
+		},
+	}
+
+	runCompilerTests(t, tests)
+}
+
 func runCompilerTests(t *testing.T, tests []compilerTestCase) {
 	t.Helper()
 

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -601,6 +601,46 @@ func testConstants(t *testing.T, expected []interface{}, actual []object.Object)
 	return nil
 }
 
+func TestFunctionCalls(t *testing.T) {
+	tests := []compilerTestCase{
+		{
+			input: `fn() { 24 }();`,
+			expectedConstants: []interface{}{
+				24,
+				[]code.Instructions{
+					code.Make(code.OpConstant, 0), // The literal "24"
+					code.Make(code.OpReturnValue),
+				},
+			},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 1), // The compiled function
+				code.Make(code.OpCall),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input: `let noArg = fn() { 24; };
+noArg();`,
+			expectedConstants: []interface{}{
+				24,
+				[]code.Instructions{
+					code.Make(code.OpConstant, 0),
+					code.Make(code.OpReturnValue),
+				},
+			},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpSetGlobal, 0),
+				code.Make(code.OpGetGlobal, 0),
+				code.Make(code.OpCall),
+				code.Make(code.OpPop),
+			},
+		},
+	}
+
+	runCompilerTests(t, tests)
+}
+
 func testIntegerObject(expected int64, actual object.Object) error {
 	result, ok := actual.(*object.Integer)
 	if !ok {

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -439,6 +439,88 @@ func TestIndexExpressions(t *testing.T) {
 	runCompilerTests(t, tests)
 }
 
+func TestFunctions(t *testing.T) {
+	tests := []compilerTestCase{
+		{
+			input:             "fn() { return 5 + 10; }",
+			expectedConstants: []interface{}{5, 10},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpAdd),
+				code.Make(code.OpReturnValue),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input:             "fn() { 5 + 10; }",
+			expectedConstants: []interface{}{5, 10},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpAdd),
+				code.Make(code.OpReturnValue),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input:             "fn() { 1; 2 }",
+			expectedConstants: []interface{}{1, 2},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpPop),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpReturnValue),
+				code.Make(code.OpPop),
+			},
+		},
+	}
+
+	runCompilerTests(t, tests)
+}
+
+func TestCompilerScopes(t *testing.T) {
+	compiler := New()
+	if compiler.scopeIndex != 0 {
+		t.Errorf("scopeIndex wrong. got=%d, want=%d", compiler.scopeIndex, 0)
+	}
+	compiler.emit(code.OpMul)
+	compiler.enterScope()
+	if compiler.scopeIndex != 1 {
+		t.Errorf("scopeIndex wrong. got=%d, want=%d", compiler.scopeIndex, 1)
+	}
+	compiler.emit(code.OpSub)
+	if len(compiler.scopes[compiler.scopeIndex].instructions) != 1 {
+		t.Errorf("instructions length wrong. got=%d",
+			len(compiler.scopes[compiler.scopeIndex].instructions))
+	}
+	last := compiler.scopes[compiler.scopeIndex].lastInstruction
+	if last.Opcode != code.OpSub {
+		t.Errorf("lastInstruction.Opcode wrong. got=%d, want=%d",
+			last.Opcode, code.OpSub)
+	}
+	compiler.leaveScope()
+	if compiler.scopeIndex != 0 {
+		t.Errorf("scopeIndex wrong. got=%d, want=%d",
+			compiler.scopeIndex, 0)
+	}
+	compiler.emit(code.OpAdd)
+	if len(compiler.scopes[compiler.scopeIndex].instructions) != 2 {
+		t.Errorf("instructions length wrong. got=%d",
+			len(compiler.scopes[compiler.scopeIndex].instructions))
+	}
+	last = compiler.scopes[compiler.scopeIndex].lastInstruction
+	if last.Opcode != code.OpAdd {
+		t.Errorf("lastInstruction.Opcode wrong. got=%d, want=%d",
+			last.Opcode, code.OpAdd)
+	}
+	previous := compiler.scopes[compiler.scopeIndex].previousInstruction
+	if previous.Opcode != code.OpMul {
+		t.Errorf("previousInstruction.Opcode wrong. got=%d, want=%d",
+			previous.Opcode, code.OpMul)
+	}
+}
+
 func runCompilerTests(t *testing.T, tests []compilerTestCase) {
 	t.Helper()
 
@@ -498,6 +580,17 @@ func testConstants(t *testing.T, expected []interface{}, actual []object.Object)
 			err := testStringObject(constant, actual[i])
 			if err != nil {
 				return fmt.Errorf("constant %d - testStringObject failed: %s", i, err)
+			}
+		case []code.Instructions:
+			fn, ok := actual[i].(*object.CompiledFunction)
+			if !ok {
+				return fmt.Errorf("constant %d - not a function: %T",
+					i, actual[i])
+			}
+			err := testInstructions(constant, fn.Instructions)
+			if err != nil {
+				return fmt.Errorf("constant %d - testInstructions failed: %s",
+					i, err)
 			}
 		}
 	}

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -458,6 +458,23 @@ func TestFunctions(t *testing.T) {
 				code.Make(code.OpPop),
 			},
 		},
+		{
+			input: `fn() { 1; 2 }`,
+			expectedConstants: []interface{}{
+				1,
+				2,
+				[]code.Instructions{
+					code.Make(code.OpConstant, 0),
+					code.Make(code.OpPop),
+					code.Make(code.OpConstant, 1),
+					code.Make(code.OpReturnValue),
+				},
+			},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 2),
+				code.Make(code.OpPop),
+			},
+		},
 	}
 
 	runCompilerTests(t, tests)

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -439,29 +439,29 @@ func TestIndexExpressions(t *testing.T) {
 	runCompilerTests(t, tests)
 }
 
-// func TestFunctions(t *testing.T) {
-// 	tests := []compilerTestCase{
-// 		{
-// 			input: `fn() { return 5 + 10 }`,
-// 			expectedConstants: []interface{}{
-// 				5,
-// 				10,
-// 				[]code.Instructions{
-// 					code.Make(code.OpConstant, 0),
-// 					code.Make(code.OpConstant, 1),
-// 					code.Make(code.OpAdd),
-// 					code.Make(code.OpReturnValue),
-// 				},
-// 			},
-// 			expectedInstructions: []code.Instructions{
-// 				code.Make(code.OpConstant, 2),
-// 				code.Make(code.OpPop),
-// 			},
-// 		},
-// 	}
+func TestFunctions(t *testing.T) {
+	tests := []compilerTestCase{
+		{
+			input: `fn() { return 5 + 10 }`,
+			expectedConstants: []interface{}{
+				5,
+				10,
+				[]code.Instructions{
+					code.Make(code.OpConstant, 0),
+					code.Make(code.OpConstant, 1),
+					code.Make(code.OpAdd),
+					code.Make(code.OpReturnValue),
+				},
+			},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 2),
+				code.Make(code.OpPop),
+			},
+		},
+	}
 
-// 	runCompilerTests(t, tests)
-// }
+	runCompilerTests(t, tests)
+}
 
 func TestCompilerScopes(t *testing.T) {
 	compiler := New()

--- a/object/object.go
+++ b/object/object.go
@@ -6,6 +6,7 @@ import (
 	"hash/fnv"
 	"monkey/ast"
 	"strings"
+	"monkey/code"
 )
 
 const (
@@ -24,6 +25,7 @@ const (
 	ARRAY_OBJ = "ARRAY"
 
 	HASH_OBJ = "HASH"
+	COMPILED_FUNCTION_OBJ = "COMPILED_FUNCTION"
 )
 
 type ObjectType string
@@ -180,4 +182,13 @@ func (h *Hash) Inspect() string {
 
 type Hashable interface {
 	HashKey() HashKey
+}
+
+type CompiledFunction struct {
+	Instructions code.Instructions
+}
+
+func (cf *CompiledFunction) Type() ObjectType { return COMPILED_FUNCTION_OBJ }
+func (cf *CompiledFunction) Inspect() string {
+	return fmt.Sprintf("CompiledFunction[%p]", cf)
 }

--- a/object/object.go
+++ b/object/object.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"hash/fnv"
 	"monkey/ast"
-	"strings"
 	"monkey/code"
+	"strings"
 )
 
 const (
@@ -24,7 +24,7 @@ const (
 
 	ARRAY_OBJ = "ARRAY"
 
-	HASH_OBJ = "HASH"
+	HASH_OBJ              = "HASH"
 	COMPILED_FUNCTION_OBJ = "COMPILED_FUNCTION"
 )
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -159,7 +159,7 @@ func (p *Parser) parseReturnStatement() *ast.ReturnStatement {
 
 	stmt.ReturnValue = p.parseExpression(LOWEST)
 
-	for !p.curTokenIs(token.SEMICOLON) {
+	for p.peekTokenIs(token.SEMICOLON) {
 		p.nextToken()
 	}
 

--- a/vm/frame.go
+++ b/vm/frame.go
@@ -1,0 +1,21 @@
+package vm
+
+import (
+	"monkey/code"
+	"monkey/object"
+	)
+
+type Frame struct {
+	fn *object.CompiledFunction
+	ip int
+}
+
+func NewFrame(fn *object.CompiledFunction) *Frame {
+	return &Frame{fn: fn, ip: -1}
+}
+
+func (f *Frame) Instructions() code.Instructions {
+	return f.fn.Instructions
+}
+
+

--- a/vm/frame.go
+++ b/vm/frame.go
@@ -3,7 +3,7 @@ package vm
 import (
 	"monkey/code"
 	"monkey/object"
-	)
+)
 
 type Frame struct {
 	fn *object.CompiledFunction
@@ -17,5 +17,3 @@ func NewFrame(fn *object.CompiledFunction) *Frame {
 func (f *Frame) Instructions() code.Instructions {
 	return f.fn.Instructions
 }
-
-

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -166,6 +166,31 @@ func (vm *VM) Run() error {
 			if err != nil {
 				return err
 			}
+		case code.OpCall:
+			fn, ok := vm.stack[vm.sp-1].(*object.CompiledFunction)
+			if !ok {
+				return fmt.Errorf("calling non-function")
+			}
+			frame := NewFrame(fn)
+			vm.pushFrame(frame)
+		case code.OpReturnValue:
+			returnValue := vm.pop()
+
+			vm.popFrame()
+			vm.pop()
+
+			err := vm.push(returnValue)
+			if err != nil {
+				return err
+			}
+		case code.OpReturn:
+			vm.popFrame()
+			vm.pop()
+
+			err := vm.push(Null)
+			if err != nil {
+				return err
+			}
 		case code.OpPop:
 			vm.pop()
 		}

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -65,13 +65,14 @@ func (vm *VM) Run() error {
 
 	for vm.currentFrame().ip < len(vm.currentFrame().Instructions())-1 {
 		vm.currentFrame().ip++
+
 		ip = vm.currentFrame().ip
 		ins = vm.currentFrame().Instructions()
 
 		op = code.Opcode(ins[ip])
 		switch op {
 		case code.OpConstant:
-			constIndex := code.ReadUint16(vm.instructions[ip+1:])
+			constIndex := code.ReadUint16(ins[ip+1:])
 			vm.currentFrame().ip += 2
 			err := vm.push(vm.constants[constIndex])
 			if err != nil {
@@ -108,11 +109,11 @@ func (vm *VM) Run() error {
 				return err
 			}
 		case code.OpJump:
-			pos := int(code.ReadUint16(vm.instructions[ip+1:]))
+			pos := int(code.ReadUint16(ins[ip+1:]))
 			vm.currentFrame().ip = pos - 1
 		case code.OpJumpNotTruthy:
-			pos := int(code.ReadUint16(vm.instructions[ip+1:]))
-			ip += 2
+			pos := int(code.ReadUint16(ins[ip+1:]))
+			vm.currentFrame().ip += 2
 
 			condition := vm.pop()
 			if !isTruthy(condition) {
@@ -124,18 +125,18 @@ func (vm *VM) Run() error {
 				return err
 			}
 		case code.OpSetGlobal:
-			globalIndex := code.ReadUint16(vm.instructions[ip+1:])
+			globalIndex := code.ReadUint16(ins[ip+1:])
 			vm.currentFrame().ip += 2
 			vm.globals[globalIndex] = vm.pop()
 		case code.OpGetGlobal:
-			globalIndex := code.ReadUint16(vm.instructions[ip+1:])
+			globalIndex := code.ReadUint16(ins[ip+1:])
 			vm.currentFrame().ip += 2
 			err := vm.push(vm.globals[globalIndex])
 			if err != nil {
 				return err
 			}
 		case code.OpArray:
-			numElements := int(code.ReadUint16(vm.instructions[ip+1:]))
+			numElements := int(code.ReadUint16(ins[ip+1:]))
 			vm.currentFrame().ip += 2
 
 			array := vm.buildArray(vm.sp-numElements, vm.sp)
@@ -145,7 +146,7 @@ func (vm *VM) Run() error {
 				return err
 			}
 		case code.OpHash:
-			numElements := int(code.ReadUint16(vm.instructions[ip+1:]))
+			numElements := int(code.ReadUint16(ins[ip+1:]))
 			vm.currentFrame().ip += 2
 
 			hash, err := vm.buildHash(vm.sp-numElements, vm.sp)

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -9,6 +9,7 @@ import (
 
 const StackSize = 2048
 const GlobalsSize = 65536
+const MaxFrames = 1024
 
 var True = &object.Boolean{Value: true}
 var False = &object.Boolean{Value: false}
@@ -21,16 +22,26 @@ type VM struct {
 	stack   []object.Object
 	sp      int
 	globals []object.Object
+
+	frames     []*Frame
+	frameIndex int
 }
 
 func New(bytecode *compiler.Bytecode) *VM {
+	mainFn := &object.CompiledFunction{Instructions: bytecode.Instructions}
+	mainFrame := NewFrame(mainFn)
+	frames := make([]*Frame, MaxFrames)
+	frames[0] = mainFrame
+
 	return &VM{
 		constants:    bytecode.Constants,
 		instructions: bytecode.Instructions,
 
-		stack:   make([]object.Object, StackSize),
-		sp:      0,
-		globals: make([]object.Object, GlobalsSize),
+		stack:      make([]object.Object, StackSize),
+		sp:         0,
+		globals:    make([]object.Object, GlobalsSize),
+		frames:     frames,
+		frameIndex: 1,
 	}
 }
 
@@ -48,12 +59,20 @@ func (vm *VM) StackTop() object.Object {
 }
 
 func (vm *VM) Run() error {
-	for ip := 0; ip < len(vm.instructions); ip++ {
-		op := code.Opcode(vm.instructions[ip])
+	var ip int
+	var ins code.Instructions
+	var op code.Opcode
+
+	for vm.currentFrame().ip < len(vm.currentFrame().Instructions())-1 {
+		vm.currentFrame().ip++
+		ip = vm.currentFrame().ip
+		ins = vm.currentFrame().Instructions()
+
+		op = code.Opcode(ins[ip])
 		switch op {
 		case code.OpConstant:
 			constIndex := code.ReadUint16(vm.instructions[ip+1:])
-			ip += 2
+			vm.currentFrame().ip += 2
 			err := vm.push(vm.constants[constIndex])
 			if err != nil {
 				return err
@@ -90,14 +109,14 @@ func (vm *VM) Run() error {
 			}
 		case code.OpJump:
 			pos := int(code.ReadUint16(vm.instructions[ip+1:]))
-			ip = pos - 1
+			vm.currentFrame().ip = pos - 1
 		case code.OpJumpNotTruthy:
 			pos := int(code.ReadUint16(vm.instructions[ip+1:]))
 			ip += 2
 
 			condition := vm.pop()
 			if !isTruthy(condition) {
-				ip = pos - 1
+				vm.currentFrame().ip = pos - 1
 			}
 		case code.OpNull:
 			err := vm.push(Null)
@@ -106,18 +125,18 @@ func (vm *VM) Run() error {
 			}
 		case code.OpSetGlobal:
 			globalIndex := code.ReadUint16(vm.instructions[ip+1:])
-			ip += 2
+			vm.currentFrame().ip += 2
 			vm.globals[globalIndex] = vm.pop()
 		case code.OpGetGlobal:
 			globalIndex := code.ReadUint16(vm.instructions[ip+1:])
-			ip += 2
+			vm.currentFrame().ip += 2
 			err := vm.push(vm.globals[globalIndex])
 			if err != nil {
 				return err
 			}
 		case code.OpArray:
 			numElements := int(code.ReadUint16(vm.instructions[ip+1:]))
-			ip += 2
+			vm.currentFrame().ip += 2
 
 			array := vm.buildArray(vm.sp-numElements, vm.sp)
 			vm.sp = vm.sp - numElements
@@ -127,7 +146,7 @@ func (vm *VM) Run() error {
 			}
 		case code.OpHash:
 			numElements := int(code.ReadUint16(vm.instructions[ip+1:]))
-			ip += 2
+			vm.currentFrame().ip += 2
 
 			hash, err := vm.buildHash(vm.sp-numElements, vm.sp)
 			if err != nil {
@@ -359,4 +378,18 @@ func (vm *VM) executeHashIndex(hash, index object.Object) error {
 		return vm.push(Null)
 	}
 	return vm.push(pair.Value)
+}
+
+func (vm *VM) currentFrame() *Frame {
+	return vm.frames[vm.frameIndex-1]
+}
+
+func (vm *VM) pushFrame(f *Frame) {
+	vm.frames[vm.frameIndex] = f
+	vm.frameIndex++
+}
+
+func (vm *VM) popFrame() *Frame {
+	vm.frameIndex--
+	return vm.frames[vm.frameIndex]
 }

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -176,6 +176,95 @@ func TestIndexExpressions(t *testing.T) {
 	runVmTests(t, tests)
 }
 
+func TestCallingFunctionsWithoutArguments(t *testing.T) {
+	tests := []vmTestCase{
+		{
+			input: `
+		let fivePlusTen = fn() { 5 + 10; };
+		fivePlusTen();
+		`,
+			expected: 15,
+		},
+		{
+			input: `
+			let one = fn() { 1; };
+			let two = fn() { 2; };
+			one() + two()
+			`,
+			expected: 3,
+		},
+		{
+			input: `
+			let a = fn() { 1 };
+			let b = fn() { a() + 1 };
+			let c = fn() { b() + 1 };
+			c();
+			`,
+			expected: 3,
+		},
+	}
+
+	runVmTests(t, tests)
+}
+
+func TestFunctionsWithReturnStatement(t *testing.T) {
+	tests := []vmTestCase{
+		{
+			input: `
+		let earlyExit = fn() { return 99; 100; };
+		earlyExit();
+		`,
+			expected: 99,
+		},
+		{
+			input: `
+		let earlyExit = fn() { return 99; return 100; };
+		earlyExit();
+		`,
+			expected: 99,
+		},
+	}
+
+	runVmTests(t, tests)
+}
+
+func TestFunctionsWithoutReturnValue(t *testing.T) {
+	tests := []vmTestCase{
+		{
+			input: `
+		let noReturn = fn() { };
+		noReturn();
+		`,
+			expected: Null,
+		},
+		{
+			input: `
+		let noReturn = fn() { };
+		let noReturnTwo = fn() { noReturn(); };
+		noReturn();
+		noReturnTwo();
+		`,
+			expected: Null,
+		},
+	}
+
+	runVmTests(t, tests)
+}
+
+func TestFirstClassFunctions(t *testing.T) {
+	tests := []vmTestCase{
+		{
+			input: `
+		let returnsOne = fn() { 1; };
+		let returnsOneReturner = fn() { returnsOne; };
+		returnsOneReturner()();
+		`,
+			expected: 1,
+		},
+	}
+	runVmTests(t, tests)
+}
+
 func parse(input string) *ast.Program {
 	l := lexer.New(input)
 	p := parser.New(l)


### PR DESCRIPTION
This pull request introduces several significant changes to the `compiler` and `vm` packages to support function calls and improve the handling of scopes. The most important changes include adding new opcodes, modifying the compiler to handle function literals and calls, and updating the virtual machine to manage frames and execute function calls.

### Compiler Improvements:
* Added new opcodes `OpCall`, `OpReturnValue`, and `OpReturn` to `code.go` to support function calls and returns. [[1]](diffhunk://#diff-2ad350013d16e8e5c021ee6f046700bb0b8249a3baa1fe88c79aac3c06c214bbR40-R42) [[2]](diffhunk://#diff-2ad350013d16e8e5c021ee6f046700bb0b8249a3baa1fe88c79aac3c06c214bbR67-R69)
* Refactored the `Compiler` struct in `compiler.go` to include a `symbolTable`, `scopes`, and `scopeIndex` for better scope management.
* Enhanced the `Compile` method in `compiler.go` to handle `FunctionLiteral`, `ReturnStatement`, and `CallExpression` nodes.
* Added new methods to manage scopes, such as `enterScope`, `leaveScope`, and `replaceLastPopWithReturn`, in `compiler.go`.

### Virtual Machine Enhancements:
* Introduced the `Frame` struct in `frame.go` to represent function call frames.
* Updated the `VM` struct in `vm.go` to include a `frames` stack and `frameIndex` for managing function call frames.
* Modified the `Run` method in `vm.go` to handle the new opcodes and manage the execution of function calls and returns. [[1]](diffhunk://#diff-c087fa7dffa5d472e6b7b59eb8f8bafd4208832487a1429e0fcfc38a9fe05167L51-R76) [[2]](diffhunk://#diff-c087fa7dffa5d472e6b7b59eb8f8bafd4208832487a1429e0fcfc38a9fe05167L92-R140) [[3]](diffhunk://#diff-c087fa7dffa5d472e6b7b59eb8f8bafd4208832487a1429e0fcfc38a9fe05167R169-R193)

### Object Model Updates:
* Added a new `CompiledFunction` type in `object.go` to represent compiled functions.

### Testing Enhancements:
* Added new tests in `compiler_test.go` and `vm_test.go` to verify the correct compilation and execution of functions, including tests for functions without return values and nested function calls. [[1]](diffhunk://#diff-cc1616f55ca6edd2c0685642afa94d589da91d1bf06e7b787695782b16dd5145R442-R526) [[2]](diffhunk://#diff-cc1616f55ca6edd2c0685642afa94d589da91d1bf06e7b787695782b16dd5145R587-R643) [[3]](diffhunk://#diff-11f0bc114469cd5519c577c6688384edf8786c307023e008682ffa72dacd8e07R179-R267)