### PR TITLE
Local binding

### DIFF
--- a/code/code_test.go
+++ b/code/code_test.go
@@ -10,6 +10,7 @@ func TestMake(t *testing.T) {
 	}{
 		{OpConstant, []int{65534}, []byte{byte(OpConstant), 255, 254}},
 		{OpAdd, []int{}, []byte{byte(OpAdd)}},
+		{OpGetLocal, []int{255}, []byte{byte(OpGetLocal), 255}},
 	}
 
 	for _, tt := range tests {
@@ -30,12 +31,14 @@ func TestMake(t *testing.T) {
 func TestInstructionsString(t *testing.T) {
 	instructions := []Instructions{
 		Make(OpAdd),
+		Make(OpGetLocal, 1),
 		Make(OpConstant, 2),
 		Make(OpConstant, 65535),
 	}
 	expected := `0000 OpAdd
-0001 OpConstant 2
-0004 OpConstant 65535
+0001 OpGetLocal 1
+0003 OpConstant 2
+0006 OpConstant 65535
 `
 	concatted := Instructions{}
 	for _, ins := range instructions {
@@ -55,6 +58,7 @@ func TestReadOperands(t *testing.T) {
 		bytesRead int
 	}{
 		{OpConstant, []int{65535}, 2},
+		{OpGetLocal, []int{255}, 1},
 	}
 
 	for _, tt := range tests {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -245,8 +245,12 @@ func (c *Compiler) Compile(node ast.Node) error {
 			c.emit(code.OpReturn)
 		}
 
+		numLocals := c.symbolTable.numDefinitions
 		instructions := c.leaveScope()
-		compiledFn := &object.CompiledFunction{Instructions: instructions}
+		compiledFn := &object.CompiledFunction{
+			Instructions: instructions,
+			NumLocals:    numLocals,
+		}
 		c.emit(code.OpConstant, c.addConstant(compiledFn))
 	case *ast.ReturnStatement:
 		err := c.Compile(node.ReturnValue)

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -39,6 +39,7 @@ func New() *Compiler {
 		constants:   []object.Object{},
 		symbolTable: NewSymbolTable(),
 		scopes:      []CompilationScope{mainScope},
+		scopeIndex:  0,
 	}
 }
 
@@ -174,13 +175,21 @@ func (c *Compiler) Compile(node ast.Node) error {
 			return err
 		}
 		symbol := c.symbolTable.Define(node.Name.Value)
-		c.emit(code.OpSetGlobal, symbol.Index)
+		if symbol.Scope == GlobalScope {
+			c.emit(code.OpSetGlobal, symbol.Index)
+		} else {
+			c.emit(code.OpSetLocal, symbol.Index)
+		}
 	case *ast.Identifier:
 		symbol, ok := c.symbolTable.Resolve(node.Value)
 		if !ok {
 			return fmt.Errorf("undefined variable %s", node.Value)
 		}
-		c.emit(code.OpGetGlobal, symbol.Index)
+		if symbol.Scope == GlobalScope {
+			c.emit(code.OpGetGlobal, symbol.Index)
+		} else {
+			c.emit(code.OpGetLocal, symbol.Index)
+		}
 	case *ast.StringLiteral:
 		str := &object.String{Value: node.Value}
 		c.emit(code.OpConstant, c.addConstant(str))
@@ -332,12 +341,16 @@ func (c *Compiler) enterScope() {
 	}
 	c.scopes = append(c.scopes, scope)
 	c.scopeIndex++
+
+	c.symbolTable = NewEnclosedSymbolTable(c.symbolTable)
 }
 
 func (c *Compiler) leaveScope() code.Instructions {
 	instructions := c.currentInstructions()
 	c.scopes = c.scopes[:len(c.scopes)-1]
 	c.scopeIndex--
+
+	c.symbolTable = c.symbolTable.Outer
 	return instructions
 }
 
@@ -348,5 +361,8 @@ func (c *Compiler) replaceLastPopWithReturn() {
 }
 
 func (c *Compiler) lastInstructionIs(op code.Opcode) bool {
+	if len(c.currentInstructions()) == 0 {
+		return false
+	}
 	return c.scopes[c.scopeIndex].lastInstruction.Opcode == op
 }

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -485,6 +485,7 @@ func TestCompilerScopes(t *testing.T) {
 	if compiler.scopeIndex != 0 {
 		t.Errorf("scopeIndex wrong. got=%d, want=%d", compiler.scopeIndex, 0)
 	}
+	globalSymbolTable := compiler.symbolTable
 	compiler.emit(code.OpMul)
 	compiler.enterScope()
 	if compiler.scopeIndex != 1 {
@@ -500,10 +501,16 @@ func TestCompilerScopes(t *testing.T) {
 		t.Errorf("lastInstruction.Opcode wrong. got=%d, want=%d",
 			last.Opcode, code.OpSub)
 	}
+	if compiler.symbolTable.Outer != globalSymbolTable {
+		t.Errorf("compiler did not enclose symbolTable")
+	}
 	compiler.leaveScope()
 	if compiler.scopeIndex != 0 {
 		t.Errorf("scopeIndex wrong. got=%d, want=%d",
 			compiler.scopeIndex, 0)
+	}
+	if compiler.symbolTable != globalSymbolTable {
+		t.Errorf("compiler did not enclose symbolTable")
 	}
 	compiler.emit(code.OpAdd)
 	if len(compiler.scopes[compiler.scopeIndex].instructions) != 2 {
@@ -655,6 +662,78 @@ noArg();`,
 		},
 	}
 
+	runCompilerTests(t, tests)
+}
+
+func TestLetStatementScopes(t *testing.T) {
+	tests := []compilerTestCase{
+		{
+			input: `
+		let num = 55;
+		fn() { num }
+		`,
+			expectedConstants: []interface{}{
+				55,
+				[]code.Instructions{
+					code.Make(code.OpGetGlobal, 0),
+					code.Make(code.OpReturnValue),
+				},
+			},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpSetGlobal, 0),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input: `
+			fn() {
+			let num = 55;
+			num
+			}
+			`,
+			expectedConstants: []interface{}{
+				55,
+				[]code.Instructions{
+					code.Make(code.OpConstant, 0),
+					code.Make(code.OpSetLocal, 0),
+					code.Make(code.OpGetLocal, 0),
+					code.Make(code.OpReturnValue),
+				},
+			},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input: `fn() {
+			let a = 55;
+			let b = 77;
+			a + b
+			}
+			`,
+			expectedConstants: []interface{}{
+				55,
+				77,
+				[]code.Instructions{
+					code.Make(code.OpConstant, 0),
+					code.Make(code.OpSetLocal, 0),
+					code.Make(code.OpConstant, 1),
+					code.Make(code.OpSetLocal, 1),
+					code.Make(code.OpGetLocal, 0),
+					code.Make(code.OpGetLocal, 1),
+					code.Make(code.OpAdd),
+					code.Make(code.OpReturnValue),
+				},
+			},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 2),
+				code.Make(code.OpPop),
+			},
+		},
+	}
 	runCompilerTests(t, tests)
 }
 

--- a/compiler/symbol_table.go
+++ b/compiler/symbol_table.go
@@ -4,6 +4,7 @@ type SymbolScope string
 
 const (
 	GlobalScope SymbolScope = "GLOBAL"
+	LocalScope  SymbolScope = "LOCAL"
 )
 
 type Symbol struct {
@@ -13,6 +14,7 @@ type Symbol struct {
 }
 
 type SymbolTable struct {
+	Outer          *SymbolTable
 	store          map[string]Symbol
 	numDefinitions int
 }
@@ -22,8 +24,19 @@ func NewSymbolTable() *SymbolTable {
 	return &SymbolTable{store: s}
 }
 
+func NewEnclosedSymbolTable(outer *SymbolTable) *SymbolTable {
+	s := NewSymbolTable()
+	s.Outer = outer
+	return s
+}
+
 func (s *SymbolTable) Define(name string) Symbol {
-	symbol := Symbol{Name: name, Index: s.numDefinitions, Scope: GlobalScope}
+	symbol := Symbol{Name: name, Index: s.numDefinitions}
+	if s.Outer == nil {
+		symbol.Scope = GlobalScope
+	} else {
+		symbol.Scope = LocalScope
+	}
 	s.store[name] = symbol
 	s.numDefinitions++
 	return symbol
@@ -31,5 +44,9 @@ func (s *SymbolTable) Define(name string) Symbol {
 
 func (s *SymbolTable) Resolve(name string) (Symbol, bool) {
 	obj, ok := s.store[name]
+	if !ok && s.Outer != nil {
+		obj, ok = s.Outer.Resolve(name)
+		return obj, ok
+	}
 	return obj, ok
 }

--- a/compiler/symbol_table_test.go
+++ b/compiler/symbol_table_test.go
@@ -6,6 +6,10 @@ func TestDefine(t *testing.T) {
 	expected := map[string]Symbol{
 		"a": {Name: "a", Scope: GlobalScope, Index: 0},
 		"b": {Name: "b", Scope: GlobalScope, Index: 1},
+		"c": {Name: "c", Scope: LocalScope, Index: 0},
+		"d": {Name: "d", Scope: LocalScope, Index: 1},
+		"e": {Name: "e", Scope: LocalScope, Index: 0},
+		"f": {Name: "f", Scope: LocalScope, Index: 1},
 	}
 	global := NewSymbolTable()
 	a := global.Define("a")
@@ -15,6 +19,24 @@ func TestDefine(t *testing.T) {
 	b := global.Define("b")
 	if b != expected["b"] {
 		t.Errorf("expected b=%+v, got=%+v", expected["b"], b)
+	}
+	firstLocal := NewEnclosedSymbolTable(global)
+	c := firstLocal.Define("c")
+	if c != expected["c"] {
+		t.Errorf("expected c=%+v, got=%+v", expected["c"], c)
+	}
+	d := firstLocal.Define("d")
+	if d != expected["d"] {
+		t.Errorf("expected d=%+v, got=%+v", expected["d"], d)
+	}
+	secondLocal := NewEnclosedSymbolTable(firstLocal)
+	e := secondLocal.Define("e")
+	if e != expected["e"] {
+		t.Errorf("expected e=%+v, got=%+v", expected["e"], e)
+	}
+	f := secondLocal.Define("f")
+	if f != expected["f"] {
+		t.Errorf("expected f=%+v, got=%+v", expected["f"], f)
 	}
 }
 
@@ -35,6 +57,82 @@ func TestResolveGlobal(t *testing.T) {
 		if result != sym {
 			t.Errorf("expected %s to resolve to %+v, got=%+v",
 				sym.Name, sym, result)
+		}
+	}
+}
+
+func TestResolveLocal(t *testing.T) {
+	global := NewSymbolTable()
+	global.Define("a")
+	global.Define("b")
+
+	local := NewEnclosedSymbolTable(global)
+	local.Define("c")
+	local.Define("d")
+	expected := []Symbol{
+		{Name: "a", Scope: GlobalScope, Index: 0},
+		{Name: "b", Scope: GlobalScope, Index: 1},
+		{Name: "c", Scope: LocalScope, Index: 0},
+		{Name: "d", Scope: LocalScope, Index: 1},
+	}
+	for _, sym := range expected {
+		result, ok := local.Resolve(sym.Name)
+		if !ok {
+			t.Errorf("name %s not resolvable", sym.Name)
+			continue
+		}
+		if result != sym {
+			t.Errorf("expected %s to resolve to %+v, got=%+v",
+				sym.Name, sym, result)
+		}
+	}
+}
+
+func TestResolveNestedLocal(t *testing.T) {
+	global := NewSymbolTable()
+	global.Define("a")
+	global.Define("b")
+	firstLocal := NewEnclosedSymbolTable(global)
+	firstLocal.Define("c")
+	firstLocal.Define("d")
+	secondLocal := NewEnclosedSymbolTable(firstLocal)
+	secondLocal.Define("e")
+	secondLocal.Define("f")
+
+	tests := []struct {
+		table           *SymbolTable
+		expectedSymbols []Symbol
+	}{
+		{
+			firstLocal,
+			[]Symbol{
+				{Name: "a", Scope: GlobalScope, Index: 0},
+				{Name: "b", Scope: GlobalScope, Index: 1},
+				{Name: "c", Scope: LocalScope, Index: 0},
+				{Name: "d", Scope: LocalScope, Index: 1},
+			},
+		},
+		{
+			secondLocal,
+			[]Symbol{
+				{Name: "a", Scope: GlobalScope, Index: 0},
+				{Name: "b", Scope: GlobalScope, Index: 1},
+				{Name: "e", Scope: LocalScope, Index: 0},
+				{Name: "f", Scope: LocalScope, Index: 1},
+			},
+		},
+	}
+	for _, tt := range tests {
+		for _, sym := range tt.expectedSymbols {
+			result, ok := tt.table.Resolve(sym.Name)
+			if !ok {
+				t.Errorf("name %s not resolvable", sym.Name)
+				continue
+			}
+			if result != sym {
+				t.Errorf("expected %s to resolve to %+v, got=%+v",
+					sym.Name, sym, result)
+			}
 		}
 	}
 }

--- a/object/object.go
+++ b/object/object.go
@@ -186,6 +186,7 @@ type Hashable interface {
 
 type CompiledFunction struct {
 	Instructions code.Instructions
+	NumLocals    int
 }
 
 func (cf *CompiledFunction) Type() ObjectType { return COMPILED_FUNCTION_OBJ }

--- a/vm/frame.go
+++ b/vm/frame.go
@@ -6,12 +6,17 @@ import (
 )
 
 type Frame struct {
-	fn *object.CompiledFunction
-	ip int
+	fn          *object.CompiledFunction
+	ip          int
+	basePointer int
 }
 
-func NewFrame(fn *object.CompiledFunction) *Frame {
-	return &Frame{fn: fn, ip: -1}
+func NewFrame(fn *object.CompiledFunction, basePointer int) *Frame {
+	return &Frame{
+		fn:          fn,
+		ip:          -1,
+		basePointer: basePointer,
+	}
 }
 
 func (f *Frame) Instructions() code.Instructions {

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -29,7 +29,7 @@ type VM struct {
 
 func New(bytecode *compiler.Bytecode) *VM {
 	mainFn := &object.CompiledFunction{Instructions: bytecode.Instructions}
-	mainFrame := NewFrame(mainFn)
+	mainFrame := NewFrame(mainFn, 0)
 	frames := make([]*Frame, MaxFrames)
 	frames[0] = mainFrame
 
@@ -171,23 +171,37 @@ func (vm *VM) Run() error {
 			if !ok {
 				return fmt.Errorf("calling non-function")
 			}
-			frame := NewFrame(fn)
+			frame := NewFrame(fn, vm.sp)
 			vm.pushFrame(frame)
+			vm.sp = frame.basePointer + fn.NumLocals
 		case code.OpReturnValue:
 			returnValue := vm.pop()
 
-			vm.popFrame()
-			vm.pop()
+			frame := vm.popFrame()
+			vm.sp = frame.basePointer - 1
 
 			err := vm.push(returnValue)
 			if err != nil {
 				return err
 			}
 		case code.OpReturn:
-			vm.popFrame()
-			vm.pop()
+			frame := vm.popFrame()
+			vm.sp = frame.basePointer - 1
 
 			err := vm.push(Null)
+			if err != nil {
+				return err
+			}
+		case code.OpSetLocal:
+			localIndex := code.ReadUint8(ins[ip+1:])
+			vm.currentFrame().ip += 1
+			frame := vm.currentFrame()
+			vm.stack[frame.basePointer+int(localIndex)] = vm.pop()
+		case code.OpGetLocal:
+			localIndex := code.ReadUint8(ins[ip+1:])
+			vm.currentFrame().ip += 1
+			frame := vm.currentFrame()
+			err := vm.push(vm.stack[frame.basePointer+int(localIndex)])
 			if err != nil {
 				return err
 			}

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -265,6 +265,58 @@ func TestFirstClassFunctions(t *testing.T) {
 	runVmTests(t, tests)
 }
 
+func TestCallingFunctionsWithBindings(t *testing.T) {
+	tests := []vmTestCase{
+		{
+			input: `
+		let one = fn() { let one = 1; one };
+		one();
+		`,
+			expected: 1,
+		},
+		{
+			input: `
+		let oneAndTwo = fn() { let one = 1; let two = 2; one + two; };
+		oneAndTwo();
+		`,
+			expected: 3,
+		},
+		{
+			input: `
+		let oneAndTwo = fn() { let one = 1; let two = 2; one + two; };
+		let threeAndFour = fn() { let three = 3; let four = 4; three + four; };
+		oneAndTwo() + threeAndFour();
+		`,
+			expected: 10,
+		},
+		{
+			input: `
+		let firstFoobar = fn() { let foobar = 50; foobar; };
+		let secondFoobar = fn() { let foobar = 100; foobar; };
+		firstFoobar() + secondFoobar();
+		`,
+			expected: 150,
+		},
+		{
+			input: `
+		let globalSeed = 50;
+		let minusOne = fn() {
+			let num = 1;
+			globalSeed - num;
+		}
+		let minusTwo = fn() {
+			let num = 2;
+			globalSeed - num;
+		}
+		minusOne() + minusTwo();
+		`,
+			expected: 97,
+		},
+	}
+
+	runVmTests(t, tests)
+}
+
 func parse(input string) *ast.Program {
 	l := lexer.New(input)
 	p := parser.New(l)


### PR DESCRIPTION
This pull request introduces several enhancements and bug fixes to the compiler and virtual machine components. The most significant changes include the addition of support for local variables, updates to the symbol table to handle nested scopes, and adjustments to the virtual machine to correctly manage function calls and local variables.

### Enhancements to the Compiler:
* Added support for local variables with new opcodes `OpGetLocal` and `OpSetLocal` in `code.go` and their corresponding definitions. [[1]](diffhunk://#diff-2ad350013d16e8e5c021ee6f046700bb0b8249a3baa1fe88c79aac3c06c214bbR43-R44) [[2]](diffhunk://#diff-2ad350013d16e8e5c021ee6f046700bb0b8249a3baa1fe88c79aac3c06c214bbR72-R73)
* Modified the `Compile` method in `compiler.go` to emit the correct opcodes for local variable access and assignments. [[1]](diffhunk://#diff-d3cde2dec4b7c2263747b17d43f704418e6657b49583254628bcad1d1052471bR178-R192) [[2]](diffhunk://#diff-d3cde2dec4b7c2263747b17d43f704418e6657b49583254628bcad1d1052471bR248-R253)
* Introduced `NewEnclosedSymbolTable` to handle nested scopes in the symbol table and updated `Define` and `Resolve` methods to support local scopes. [[1]](diffhunk://#diff-cf3d9e23db2aed625c3ebd5e3a3c14ace3c3c5e055c2e555f5b8474dcf2b1b45R27-R50) [[2]](diffhunk://#diff-cf3d9e23db2aed625c3ebd5e3a3c14ace3c3c5e055c2e555f5b8474dcf2b1b45R17)

### Virtual Machine Adjustments:
* Updated the `Frame` struct and `NewFrame` function to include a `basePointer` to manage local variables' memory.
* Modified the `Run` method in `vm.go` to handle the new opcodes for local variable operations and correctly manage the stack pointer during function calls.

### Tests and Validation:
* Added new test cases in `compiler_test.go` and `symbol_table_test.go` to validate the correct handling of local variables and nested scopes. [[1]](diffhunk://#diff-cc1616f55ca6edd2c0685642afa94d589da91d1bf06e7b787695782b16dd5145R668-R739) [[2]](diffhunk://#diff-501bee9e5e9bafb128d8bd634d5735514a6804a2abeb11a7d8590b940653b937R63-R138)
* Introduced tests in `vm_test.go` to ensure the virtual machine correctly executes functions with local bindings.

These changes collectively enhance the language's capability to handle local variables and nested scopes, ensuring more robust and flexible code execution.

### Detailed Changes:
#### Compiler Enhancements:
* [`code.go`](diffhunk://#diff-2ad350013d16e8e5c021ee6f046700bb0b8249a3baa1fe88c79aac3c06c214bbR43-R44): Added `OpGetLocal` and `OpSetLocal` opcodes and their definitions. [[1]](diffhunk://#diff-2ad350013d16e8e5c021ee6f046700bb0b8249a3baa1fe88c79aac3c06c214bbR43-R44) [[2]](diffhunk://#diff-2ad350013d16e8e5c021ee6f046700bb0b8249a3baa1fe88c79aac3c06c214bbR72-R73)
* [`compiler.go`](diffhunk://#diff-d3cde2dec4b7c2263747b17d43f704418e6657b49583254628bcad1d1052471bR178-R192): Updated `Compile` method to handle local variables and emit appropriate opcodes. [[1]](diffhunk://#diff-d3cde2dec4b7c2263747b17d43f704418e6657b49583254628bcad1d1052471bR178-R192) [[2]](diffhunk://#diff-d3cde2dec4b7c2263747b17d43f704418e6657b49583254628bcad1d1052471bR248-R253)
* [`symbol_table.go`](diffhunk://#diff-cf3d9e23db2aed625c3ebd5e3a3c14ace3c3c5e055c2e555f5b8474dcf2b1b45R27-R50): Introduced `NewEnclosedSymbolTable` and updated `Define` and `Resolve` methods for local scopes. [[1]](diffhunk://#diff-cf3d9e23db2aed625c3ebd5e3a3c14ace3c3c5e055c2e555f5b8474dcf2b1b45R27-R50) [[2]](diffhunk://#diff-cf3d9e23db2aed625c3ebd5e3a3c14ace3c3c5e055c2e555f5b8474dcf2b1b45R17)

#### Virtual Machine Adjustments:
* [`frame.go`](diffhunk://#diff-9f3aa0323c5a8bd85a75c1b192940c16e7b0364a8fbf587596ee5669d9eb8338R11-R19): Updated `Frame` struct and `NewFrame` function to include `basePointer`.
* [`vm.go`](diffhunk://#diff-c087fa7dffa5d472e6b7b59eb8f8bafd4208832487a1429e0fcfc38a9fe05167L174-R207): Modified `Run` method to handle new opcodes and manage stack pointer.

#### Tests and Validation:
* [`compiler_test.go`](diffhunk://#diff-cc1616f55ca6edd2c0685642afa94d589da91d1bf06e7b787695782b16dd5145R668-R739): Added tests for local variable handling and nested scopes. [[1]](diffhunk://#diff-cc1616f55ca6edd2c0685642afa94d589da91d1bf06e7b787695782b16dd5145R668-R739) [[2]](diffhunk://#diff-501bee9e5e9bafb128d8bd634d5735514a6804a2abeb11a7d8590b940653b937R63-R138)
* [`vm_test.go`](diffhunk://#diff-11f0bc114469cd5519c577c6688384edf8786c307023e008682ffa72dacd8e07R268-R319): Introduced tests for function calls with local bindings.