### PR TITLE
Buildin functions

### DIFF
--- a/code/code.go
+++ b/code/code.go
@@ -42,6 +42,7 @@ const (
 	OpReturn
 	OpGetLocal
 	OpSetLocal
+	OpGetBuiltin
 )
 
 var definitions = map[Opcode]*Definition{
@@ -71,6 +72,7 @@ var definitions = map[Opcode]*Definition{
 	OpReturn:        {"OpReturn", []int{}},
 	OpGetLocal:      {"OpGetLocal", []int{1}},
 	OpSetLocal:      {"OpSetLocal", []int{1}},
+	OpGetBuiltin:    {"OpGetBuiltin", []int{1}},
 }
 
 func Lookup(op byte) (*Definition, error) {

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -35,9 +35,14 @@ func New() *Compiler {
 		previousInstruction: EmittedInstruction{},
 	}
 
+	symbolTable := NewSymbolTable()
+	for i, v := range object.Builtins {
+		symbolTable.DefineBuiltin(i, v.Name)
+	}
+
 	return &Compiler{
 		constants:   []object.Object{},
-		symbolTable: NewSymbolTable(),
+		symbolTable: symbolTable,
 		scopes:      []CompilationScope{mainScope},
 		scopeIndex:  0,
 	}
@@ -185,11 +190,7 @@ func (c *Compiler) Compile(node ast.Node) error {
 		if !ok {
 			return fmt.Errorf("undefined variable %s", node.Value)
 		}
-		if symbol.Scope == GlobalScope {
-			c.emit(code.OpGetGlobal, symbol.Index)
-		} else {
-			c.emit(code.OpGetLocal, symbol.Index)
-		}
+		c.loadSymbol(symbol)
 	case *ast.StringLiteral:
 		str := &object.String{Value: node.Value}
 		c.emit(code.OpConstant, c.addConstant(str))
@@ -381,4 +382,15 @@ func (c *Compiler) lastInstructionIs(op code.Opcode) bool {
 		return false
 	}
 	return c.scopes[c.scopeIndex].lastInstruction.Opcode == op
+}
+
+func (c *Compiler) loadSymbol(s Symbol) {
+	switch s.Scope {
+	case GlobalScope:
+		c.emit(code.OpGetGlobal, s.Index)
+	case LocalScope:
+		c.emit(code.OpGetLocal, s.Index)
+	case BuiltinScope:
+		c.emit(code.OpGetBuiltin, s.Index)
+	}
 }

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -831,6 +831,46 @@ func TestLetStatementScopes(t *testing.T) {
 	runCompilerTests(t, tests)
 }
 
+func TestBuiltins(t *testing.T) {
+	tests := []compilerTestCase{
+		{
+			input: `
+			len([]);
+			push([], 1);
+			`,
+			expectedConstants: []interface{}{1},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpGetBuiltin, 0),
+				code.Make(code.OpArray, 0),
+				code.Make(code.OpCall, 1),
+				code.Make(code.OpPop),
+				code.Make(code.OpGetBuiltin, 5),
+				code.Make(code.OpArray, 0),
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpCall, 2),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input: `fn() { len([]) }`,
+			expectedConstants: []interface{}{
+				[]code.Instructions{
+					code.Make(code.OpGetBuiltin, 0),
+					code.Make(code.OpArray, 0),
+					code.Make(code.OpCall, 1),
+					code.Make(code.OpReturnValue),
+				},
+			},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpPop),
+			},
+		},
+	}
+
+	runCompilerTests(t, tests)
+}
+
 func testIntegerObject(expected int64, actual object.Object) error {
 	result, ok := actual.(*object.Integer)
 	if !ok {

--- a/compiler/symbol_table.go
+++ b/compiler/symbol_table.go
@@ -3,8 +3,9 @@ package compiler
 type SymbolScope string
 
 const (
-	GlobalScope SymbolScope = "GLOBAL"
-	LocalScope  SymbolScope = "LOCAL"
+	GlobalScope  SymbolScope = "GLOBAL"
+	LocalScope   SymbolScope = "LOCAL"
+	BuiltinScope SymbolScope = "BUILTIN"
 )
 
 type Symbol struct {
@@ -49,4 +50,10 @@ func (s *SymbolTable) Resolve(name string) (Symbol, bool) {
 		return obj, ok
 	}
 	return obj, ok
+}
+
+func (s *SymbolTable) DefineBuiltin(index int, name string) Symbol {
+	symbol := Symbol{Name: name, Index: index, Scope: BuiltinScope}
+	s.store[name] = symbol
+	return symbol
 }

--- a/compiler/symbol_table_test.go
+++ b/compiler/symbol_table_test.go
@@ -136,3 +136,41 @@ func TestResolveNestedLocal(t *testing.T) {
 		}
 	}
 }
+
+func TestDefineResolveBuiltins(t *testing.T) {
+	global := NewSymbolTable()
+	firstLocal := NewEnclosedSymbolTable(global)
+	secondLocal := NewEnclosedSymbolTable(firstLocal)
+
+	expected := []Symbol{
+		{Name: "a", Scope: BuiltinScope, Index: 0},
+		{Name: "c", Scope: BuiltinScope, Index: 1},
+		{Name: "e", Scope: BuiltinScope, Index: 2},
+		{Name: "f", Scope: BuiltinScope, Index: 3},
+	}
+	for i, sym := range expected {
+		global.DefineBuiltin(i, sym.Name)
+	}
+
+	tests := []struct {
+		table           *SymbolTable
+		expectedSymbols []Symbol
+	}{
+		{global, expected},
+		{firstLocal, expected},
+		{secondLocal, expected},
+	}
+	for _, tt := range tests {
+		for _, sym := range tt.expectedSymbols {
+			result, ok := tt.table.Resolve(sym.Name)
+			if !ok {
+				t.Errorf("name %s not resolvable", sym.Name)
+				continue
+			}
+			if result != sym {
+				t.Errorf("expected %s to resolve to %+v, got=%+v",
+					sym.Name, sym, result)
+			}
+		}
+	}
+}

--- a/evaluator/builtins.go
+++ b/evaluator/builtins.go
@@ -3,96 +3,10 @@ package evaluator
 import "monkey/object"
 
 var builtins = map[string]*object.Builtin{
-	"len": object.GetBuiltinByName("len"),
-	"first": {
-		Fn: func(args ...object.Object) object.Object {
-			if len(args) != 1 {
-				return newError("wrong number of arguments. got=%d, want=1",
-					len(args))
-			}
-			if args[0].Type() != object.ARRAY_OBJ {
-				return newError("argument to `first` must be ARRAY, got %s",
-					args[0].Type())
-			}
-
-			arr := args[0].(*object.Array)
-			if len(arr.Elements) > 0 {
-				return arr.Elements[0]
-			}
-
-			return NULL
-		},
-	},
-	"last": {
-		Fn: func(args ...object.Object) object.Object {
-			if len(args) != 1 {
-				return newError("wrong number of arguments. got=%d, want=1",
-					len(args))
-			}
-			if args[0].Type() != object.ARRAY_OBJ {
-				return newError("argument to `last` must be ARRAY, got %s",
-					args[0].Type())
-			}
-
-			arr := args[0].(*object.Array)
-			length := len(arr.Elements)
-			if length > 0 {
-				return arr.Elements[length-1]
-			}
-
-			return NULL
-		},
-	},
-	"rest": {
-		Fn: func(args ...object.Object) object.Object {
-			if len(args) != 1 {
-				return newError("wrong number of arguments. got=%d, want=1",
-					len(args))
-			}
-			if args[0].Type() != object.ARRAY_OBJ {
-				return newError("argument to `rest` must be ARRAY, got %s",
-					args[0].Type())
-			}
-
-			arr := args[0].(*object.Array)
-			length := len(arr.Elements)
-			if length > 0 {
-				newElements := make([]object.Object, length-1, length-1)
-				copy(newElements, arr.Elements[1:length])
-				return &object.Array{Elements: newElements}
-			}
-
-			return NULL
-		},
-	},
-	"push": {
-		Fn: func(args ...object.Object) object.Object {
-			if len(args) != 2 {
-				return newError("wrong number of arguments. got=%d, want=2",
-					len(args))
-			}
-			if args[0].Type() != object.ARRAY_OBJ {
-				return newError("argument to `push` must be ARRAY, got %s",
-					args[0].Type())
-			}
-
-			arr := args[0].(*object.Array)
-			length := len(arr.Elements)
-
-			newElements := make([]object.Object, length+1, length+1)
-			copy(newElements, arr.Elements)
-			newElements[length] = args[1]
-
-			return &object.Array{Elements: newElements}
-		},
-	},
-	"puts": {
-		Fn: func(args ...object.Object) object.Object {
-			for _, arg := range args {
-				println(arg.Inspect())
-			}
-
-			return NULL
-		},
-	},
+	"len":   object.GetBuiltinByName("len"),
+	"puts":  object.GetBuiltinByName("puts"),
+	"first": object.GetBuiltinByName("first"),
+	"last":  object.GetBuiltinByName("last"),
+	"rest":  object.GetBuiltinByName("rest"),
+	"push":  object.GetBuiltinByName("push"),
 }

--- a/evaluator/builtins.go
+++ b/evaluator/builtins.go
@@ -3,24 +3,7 @@ package evaluator
 import "monkey/object"
 
 var builtins = map[string]*object.Builtin{
-	"len": {
-		Fn: func(args ...object.Object) object.Object {
-			if len(args) != 1 {
-				return newError("wrong number of arguments. got=%d, want=1",
-					len(args))
-			}
-
-			switch arg := args[0].(type) {
-			case *object.String:
-				return &object.Integer{Value: int64(len(arg.Value))}
-			case *object.Array:
-				return &object.Integer{Value: int64(len(arg.Elements))}
-			default:
-				return newError("argument to `len` not supported, got %s",
-					args[0].Type())
-			}
-		},
-	},
+	"len": object.GetBuiltinByName("len"),
 	"first": {
 		Fn: func(args ...object.Object) object.Object {
 			if len(args) != 1 {

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -284,7 +284,10 @@ func applyFunction(fn object.Object, args []object.Object) object.Object {
 		evaluated := Eval(fn.Body, extendedEnv)
 		return unwrapReturnValue(evaluated)
 	case *object.Builtin:
-		return fn.Fn(args...)
+		if result := fn.Fn(args...); result != nil {
+			return result
+		}
+		return NULL
 	default:
 		return newError("not a function: %s", fn.Type())
 	}

--- a/object/builtins.go
+++ b/object/builtins.go
@@ -1,0 +1,51 @@
+package object
+
+import "fmt"
+
+var Builtins = []struct {
+	Name    string
+	Builtin *Builtin
+}{
+	{
+		"len",
+		&Builtin{Fn: func(args ...Object) Object {
+			if len(args) != 1 {
+				return newError("wrong number of arguments. got=%d, want=1",
+					len(args))
+			}
+			switch arg := args[0].(type) {
+			case *Array:
+				return &Integer{Value: int64(len(arg.Elements))}
+			case *String:
+				return &Integer{Value: int64(len(arg.Value))}
+			default:
+				return newError("argument to `len` not supported, got %s",
+					args[0].Type())
+			}
+		},
+		},
+	},
+	{
+		"puts",
+		&Builtin{Fn: func(args ...Object) Object {
+			for _, arg := range args {
+				fmt.Println(arg.Inspect())
+			}
+			return nil
+		},
+		},
+	},
+}
+
+func newError(format string, a ...interface{}) *Error {
+	return &Error{Message: fmt.Sprintf(format, a...)}
+}
+
+func GetBuiltinByName(name string) *Builtin {
+	for _, bi := range Builtins {
+		if bi.Name == name {
+			return bi.Builtin
+		}
+	}
+	return nil
+}

--- a/object/builtins.go
+++ b/object/builtins.go
@@ -35,6 +35,97 @@ var Builtins = []struct {
 		},
 		},
 	},
+	{
+		"first",
+		&Builtin{Fn: func(args ...Object) Object {
+			if len(args) != 1 {
+				return newError("wrong number of arguments. got=%d, want=1",
+					len(args))
+			}
+			if args[0].Type() != ARRAY_OBJ {
+				return newError("argument to `first` must be ARRAY, got %s",
+					args[0].Type())
+			}
+
+			arr := args[0].(*Array)
+			length := len(arr.Elements)
+			if length > 0 {
+				return arr.Elements[0]
+			}
+
+			return nil
+		},
+		},
+	},
+	{
+		"last",
+		&Builtin{Fn: func(args ...Object) Object {
+			if len(args) != 1 {
+				return newError("wrong number of arguments. got=%d, want=1",
+					len(args))
+			}
+			if args[0].Type() != ARRAY_OBJ {
+				return newError("argument to `last` must be ARRAY, got %s",
+					args[0].Type())
+			}
+
+			arr := args[0].(*Array)
+			length := len(arr.Elements)
+			if length > 0 {
+				return arr.Elements[length-1]
+			}
+
+			return nil
+		},
+		},
+	},
+	{
+		"rest",
+		&Builtin{Fn: func(args ...Object) Object {
+			if len(args) != 1 {
+				return newError("wrong number of arguments. got=%d, want=1",
+					len(args))
+			}
+			if args[0].Type() != ARRAY_OBJ {
+				return newError("argument to `rest` must be ARRAY, got %s",
+					args[0].Type())
+			}
+
+			arr := args[0].(*Array)
+			length := len(arr.Elements)
+			if length > 0 {
+				newElements := make([]Object, length-1, length-1)
+				copy(newElements, arr.Elements[1:length])
+				return &Array{Elements: newElements}
+			}
+
+			return nil
+		},
+		},
+	},
+	{
+		"push",
+		&Builtin{Fn: func(args ...Object) Object {
+			if len(args) != 2 {
+				return newError("wrong number of arguments. got=%d, want=2",
+					len(args))
+			}
+			if args[0].Type() != ARRAY_OBJ {
+				return newError("argument to `push` must be ARRAY, got %s",
+					args[0].Type())
+			}
+
+			arr := args[0].(*Array)
+			length := len(arr.Elements)
+
+			newElements := make([]Object, length+1, length+1)
+			copy(newElements, arr.Elements)
+			newElements[length] = args[1]
+
+			return &Array{Elements: newElements}
+		},
+		},
+	},
 }
 
 func newError(format string, a ...interface{}) *Error {

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -22,6 +22,9 @@ func Start(in io.Reader, out io.Writer) {
 	constants := []object.Object{}
 	globals := make([]object.Object, vm.GlobalsSize)
 	symbolTable := compiler.NewSymbolTable()
+	for i, v := range object.Builtins {
+		symbolTable.DefineBuiltin(i, v.Name)
+	}
 
 	for {
 		fmt.Printf(PROMPT)

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -169,7 +169,9 @@ func (vm *VM) Run() error {
 		case code.OpCall:
 			numArgs := code.ReadUint8(ins[ip+1:])
 			vm.currentFrame().ip += 1
-			err := vm.callFunction(int(numArgs))
+
+			err := vm.executeCall(int(numArgs))
+			// err := vm.callFunction(int(numArgs))
 			if err != nil {
 				return err
 			}
@@ -201,6 +203,14 @@ func (vm *VM) Run() error {
 			vm.currentFrame().ip += 1
 			frame := vm.currentFrame()
 			err := vm.push(vm.stack[frame.basePointer+int(localIndex)])
+			if err != nil {
+				return err
+			}
+		case code.OpGetBuiltin:
+			builtinIndex := code.ReadUint8(ins[ip+1:])
+			vm.currentFrame().ip += 1
+			definition := object.Builtins[builtinIndex]
+			err := vm.push(definition.Builtin)
 			if err != nil {
 				return err
 			}
@@ -433,7 +443,7 @@ func (vm *VM) popFrame() *Frame {
 	return vm.frames[vm.frameIndex]
 }
 
-func (vm *VM) callFunction(numArgs int) error {
+func (vm *VM) callFunction(fn *object.CompiledFunction, numArgs int) error {
 	fn, ok := vm.stack[vm.sp-1-numArgs].(*object.CompiledFunction)
 	if !ok {
 		return fmt.Errorf("calling non-function")
@@ -444,5 +454,29 @@ func (vm *VM) callFunction(numArgs int) error {
 	frame := NewFrame(fn, vm.sp-numArgs)
 	vm.pushFrame(frame)
 	vm.sp = frame.basePointer + fn.NumLocals
+	return nil
+}
+
+func (vm *VM) executeCall(numArgs int) error {
+	callee := vm.stack[vm.sp-1-numArgs]
+	switch callee := callee.(type) {
+	case *object.CompiledFunction:
+		return vm.callFunction(callee, numArgs)
+	case *object.Builtin:
+		return vm.callBuiltin(callee, numArgs)
+	default:
+		return fmt.Errorf("calling non-function and non-builtin")
+	}
+}
+
+func (vm *VM) callBuiltin(fn *object.Builtin, numArgs int) error {
+	args := vm.stack[vm.sp-numArgs : vm.sp]
+	result := fn.Fn(args...)
+	vm.sp = vm.sp - numArgs - 1
+	if result != nil {
+		vm.push(result)
+	} else {
+		vm.push(Null)
+	}
 	return nil
 }

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -526,7 +526,62 @@ func testExpectedObject(t *testing.T, expected interface{}, actual object.Object
 				t.Errorf("testIntegerObject failed: %s", err)
 			}
 		}
+	case *object.Error:
+		errObj, ok := actual.(*object.Error)
+		if !ok {
+			t.Errorf("object is not Error: %T (%+v)", actual, actual)
+			return
+		}
+		if errObj.Message != expected.Message {
+			t.Errorf("wrong error message. expected=%q, got=%q",
+				expected.Message, errObj.Message)
+		}
 	}
+}
+
+func TestBuiltinFunctions(t *testing.T) {
+	tests := []vmTestCase{
+		{`len("")`, 0},
+		{`len("four")`, 4},
+		{`len("hello world")`, 11},
+		{
+			`len(1)`,
+			&object.Error{
+				Message: "argument to `len` not supported, got INTEGER",
+			},
+		},
+		{`len("one", "two")`,
+			&object.Error{
+				Message: "wrong number of arguments. got=2, want=1",
+			},
+		},
+		{`len([1, 2, 3])`, 3},
+		{`len([])`, 0},
+		{`puts("hello", "world!")`, Null},
+		{`first([1, 2, 3])`, 1},
+		{`first([])`, Null},
+		{`first(1)`,
+			&object.Error{
+				Message: "argument to `first` must be ARRAY, got INTEGER",
+			},
+		},
+		{`last([1, 2, 3])`, 3},
+		{`last([])`, Null},
+		{`last(1)`,
+			&object.Error{
+				Message: "argument to `last` must be ARRAY, got INTEGER",
+			},
+		},
+		{`rest([1, 2, 3])`, []int{2, 3}},
+		{`rest([])`, Null},
+		{`push([], 1)`, []int{1}},
+		{`push(1, 1)`,
+			&object.Error{
+				Message: "argument to `push` must be ARRAY, got INTEGER",
+			},
+		},
+	}
+	runVmTests(t, tests)
 }
 
 func testBooleanObject(expected bool, actual object.Object) error {


### PR DESCRIPTION
This pull request introduces support for built-in functions in the Monkey programming language compiler and virtual machine. The changes include adding a new opcode for built-in functions, updating the symbol table to handle built-ins, and modifying the evaluator and VM to support these functions.

### Support for Built-in Functions:

* [`code/code.go`](diffhunk://#diff-2ad350013d16e8e5c021ee6f046700bb0b8249a3baa1fe88c79aac3c06c214bbR45): Added a new opcode `OpGetBuiltin` and updated the `definitions` map to include it. [[1]](diffhunk://#diff-2ad350013d16e8e5c021ee6f046700bb0b8249a3baa1fe88c79aac3c06c214bbR45) [[2]](diffhunk://#diff-2ad350013d16e8e5c021ee6f046700bb0b8249a3baa1fe88c79aac3c06c214bbR75)
* [`compiler/compiler.go`](diffhunk://#diff-d3cde2dec4b7c2263747b17d43f704418e6657b49583254628bcad1d1052471bR38-R45): Updated the `New` function to initialize the symbol table with built-ins and added a new method `loadSymbol` to handle different symbol scopes. [[1]](diffhunk://#diff-d3cde2dec4b7c2263747b17d43f704418e6657b49583254628bcad1d1052471bR38-R45) [[2]](diffhunk://#diff-d3cde2dec4b7c2263747b17d43f704418e6657b49583254628bcad1d1052471bL188-R193) [[3]](diffhunk://#diff-d3cde2dec4b7c2263747b17d43f704418e6657b49583254628bcad1d1052471bR386-R396)
* [`compiler/symbol_table.go`](diffhunk://#diff-cf3d9e23db2aed625c3ebd5e3a3c14ace3c3c5e055c2e555f5b8474dcf2b1b45R8): Added `BuiltinScope` to `SymbolScope` and a method `DefineBuiltin` to define built-in symbols. [[1]](diffhunk://#diff-cf3d9e23db2aed625c3ebd5e3a3c14ace3c3c5e055c2e555f5b8474dcf2b1b45R8) [[2]](diffhunk://#diff-cf3d9e23db2aed625c3ebd5e3a3c14ace3c3c5e055c2e555f5b8474dcf2b1b45R54-R59)
* [`object/builtins.go`](diffhunk://#diff-b99e4c5d440bbba7f3d8e3cef52ce865244a03cd8932f6c37b2b50e16f805d05R1-R142): Created a new file to define built-in functions and a method `GetBuiltinByName` to retrieve them.

### Updates to Evaluator and Virtual Machine:

* [`evaluator/builtins.go`](diffhunk://#diff-d231af81d2985497b7b1365c73c44cdef765f600f493ffb8b8f0e1c7d1eac88bL6-R11): Refactored to use the new built-in functions from `object/builtins.go`.
* [`evaluator/evaluator.go`](diffhunk://#diff-80846a8582a8797b53b71827455b4154e1c988766db890ebf9ca1403738fc8a5L287-R290): Updated the `applyFunction` method to handle built-in functions.
* [`vm/vm.go`](diffhunk://#diff-c087fa7dffa5d472e6b7b59eb8f8bafd4208832487a1429e0fcfc38a9fe05167L172-R174): Added support for the new `OpGetBuiltin` opcode and refactored function calling to handle both compiled and built-in functions. [[1]](diffhunk://#diff-c087fa7dffa5d472e6b7b59eb8f8bafd4208832487a1429e0fcfc38a9fe05167L172-R174) [[2]](diffhunk://#diff-c087fa7dffa5d472e6b7b59eb8f8bafd4208832487a1429e0fcfc38a9fe05167R209-R216) [[3]](diffhunk://#diff-c087fa7dffa5d472e6b7b59eb8f8bafd4208832487a1429e0fcfc38a9fe05167L436-R446) [[4]](diffhunk://#diff-c087fa7dffa5d472e6b7b59eb8f8bafd4208832487a1429e0fcfc38a9fe05167R459-R482)

### Testing:

* [`compiler/compiler_test.go`](diffhunk://#diff-cc1616f55ca6edd2c0685642afa94d589da91d1bf06e7b787695782b16dd5145R834-R873): Added tests for built-in functions.
* [`compiler/symbol_table_test.go`](diffhunk://#diff-501bee9e5e9bafb128d8bd634d5735514a6804a2abeb11a7d8590b940653b937R139-R176): Added tests for defining and resolving built-in symbols.
* [`vm/vm_test.go`](diffhunk://#diff-11f0bc114469cd5519c577c6688384edf8786c307023e008682ffa72dacd8e07R529-R586): Added tests for built-in functions in the VM. [[1]](diffhunk://#diff-11f0bc114469cd5519c577c6688384edf8786c307023e008682ffa72dacd8e07R529-R586) [[2]](diffhunk://#diff-11f0bc114469cd5519c577c6688384edf8786c307023e008682ffa72dacd8e07R529-R586)

These changes collectively enhance the Monkey language by integrating built-in functions, making the compiler and VM more robust and feature-rich.