### PR TITLE
Benchmark

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -1,0 +1,22 @@
+# Monkey Language Benchmarks
+
+This directory contains benchmarks for measuring the performance of the Monkey language interpreter and compiler.
+
+## Overview
+
+There are two approaches to implementing the Monkey language:
+1. Interpreter approach - directly evaluates the AST
+2. Compiler/VM approach - compiles the AST into bytecode and executes it in a VM
+
+We've prepared benchmarks to measure the performance differences between these implementations.
+
+## Running the Benchmarks
+
+To run the benchmarks, use the following commands:
+
+```bash
+cd ../
+go build -o fibonacci ./benchmark
+./fibonacci -engine=vm
+./fibonacci -engine=eval
+```

--- a/benchmark/main.go
+++ b/benchmark/main.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"monkey/compiler"
+	"monkey/evaluator"
+	"monkey/lexer"
+	"monkey/object"
+	"monkey/parser"
+	"monkey/vm"
+	"time"
+)
+
+var engine = flag.String("engine", "vm", "use 'vm' or 'eval'")
+
+var input = `
+	let fibonacci = fn(x) {
+		if (x == 0) {
+			0
+		} else {
+			if (x == 1) {
+				return 1;
+			} else {
+				fibonacci(x - 1) + fibonacci(x - 2);
+			}
+		}
+	};
+	fibonacci(35);
+	`
+
+func main() {
+	flag.Parse()
+	var duration time.Duration
+	var result object.Object
+	l := lexer.New(input)
+
+	p := parser.New(l)
+	program := p.ParseProgram()
+
+	if *engine == "vm" {
+		comp := compiler.New()
+		err := comp.Compile(program)
+		if err != nil {
+			fmt.Printf("compiler error: %s", err)
+			return
+		}
+		machine := vm.New(comp.Bytecode())
+		start := time.Now()
+		err = machine.Run()
+		if err != nil {
+			fmt.Printf("vm error: %s", err)
+			return
+		}
+		duration = time.Since(start)
+		result = machine.LastPoppedStackElem()
+	} else {
+		env := object.NewEnvironment()
+		start := time.Now()
+		result = evaluator.Eval(program, env)
+		duration = time.Since(start)
+	}
+
+	fmt.Printf(
+		"engine=%s, result=%s, duration=%s\n",
+		*engine,
+		result.Inspect(),
+		duration)
+}


### PR DESCRIPTION
This pull request introduces benchmarking capabilities for the Monkey language interpreter and compiler, providing a way to measure and compare their performance. The main changes include the addition of a README file explaining the benchmarks and a Go program to execute them.

Documentation:

* [`benchmark/README.md`](diffhunk://#diff-7fe6b01752be42136da1c4bfcc273aa482497b35192a5af3fc46027766c59ae1R1-R22): Added a new README file that explains the purpose of the benchmarks, describes the two approaches to implementing the Monkey language, and provides instructions on how to run the benchmarks.

Benchmarking implementation:

* [`benchmark/main.go`](diffhunk://#diff-a4a3d0bc2fd197155cce10083fb0a7605d64d7c287a9d941a4706b6d08b4c16bR1-R69): Added a new Go program that benchmarks the performance of the Monkey language interpreter and compiler by running a Fibonacci function. The program uses command-line flags to switch between the VM and evaluator engines and measures the execution time for each.