### PR TITLE
feat: add support for float literals and arithmetic operations

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -132,6 +132,9 @@ func (c *Compiler) Compile(node ast.Node) error {
 	case *ast.IntegerLiteral:
 		integer := &object.Integer{Value: node.Value}
 		c.emit(code.OpConstant, c.addConstant(integer))
+	case *ast.FloatLiteral:
+		float := &object.Float{Value: node.Value}
+		c.emit(code.OpConstant, c.addConstant(float))
 	case *ast.IfExpression:
 		err := c.Compile(node.Condition)
 		if err != nil {

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -620,6 +620,12 @@ func testConstants(t *testing.T, expected []interface{}, actual []object.Object)
 				return fmt.Errorf("constant %d - testIntegerObject failed: %s",
 					i, err)
 			}
+		case float64:
+			err := testFloatObject(constant, actual[i])
+			if err != nil {
+				return fmt.Errorf("constant %d - testFloatObject failed: %s",
+					i, err)
+			}
 		case string:
 			err := testStringObject(constant, actual[i])
 			if err != nil {
@@ -1081,6 +1087,53 @@ func TestRecursiveFunctions(t *testing.T) {
 	runCompilerTests(t, tests)
 }
 
+func TestFloatArithmetic(t *testing.T) {
+	tests := []compilerTestCase{
+		{
+			input:             "1.5 + 2.5",
+			expectedConstants: []interface{}{1.5, 2.5},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpAdd),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input:             "3.5 - 1.2",
+			expectedConstants: []interface{}{3.5, 1.2},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpSub),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input:             "2.5 * 3.0",
+			expectedConstants: []interface{}{2.5, 3.0},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpMul),
+				code.Make(code.OpPop),
+			},
+		},
+		{
+			input:             "10.0 / 2.0",
+			expectedConstants: []interface{}{10.0, 2.0},
+			expectedInstructions: []code.Instructions{
+				code.Make(code.OpConstant, 0),
+				code.Make(code.OpConstant, 1),
+				code.Make(code.OpDiv),
+				code.Make(code.OpPop),
+			},
+		},
+	}
+
+	runCompilerTests(t, tests)
+}
+
 func testIntegerObject(expected int64, actual object.Object) error {
 	result, ok := actual.(*object.Integer)
 	if !ok {
@@ -1088,6 +1141,18 @@ func testIntegerObject(expected int64, actual object.Object) error {
 	}
 	if result.Value != expected {
 		return fmt.Errorf("object has wrong value. got=%d, want=%d",
+			result.Value, expected)
+	}
+	return nil
+}
+
+func testFloatObject(expected float64, actual object.Object) error {
+	result, ok := actual.(*object.Float)
+	if !ok {
+		return fmt.Errorf("object is not Float. got=%T (%+v)", actual, actual)
+	}
+	if result.Value != expected {
+		return fmt.Errorf("object has wrong value. got=%f, want=%f",
 			result.Value, expected)
 	}
 	return nil

--- a/vm/vm_test.go
+++ b/vm/vm_test.go
@@ -755,3 +755,33 @@ func TestRecursiveFibonacci(t *testing.T) {
 	}
 	runVmTests(t, tests)
 }
+
+func TestFloatArithmetic(t *testing.T) {
+	tests := []vmTestCase{
+		{"1.0", 1.0},
+		{"2.0", 2.0},
+		{"1.0 + 3.0", 4.0},
+		{"2.0 + 7.0", 9.0},
+		{"7.0 - 2.0", 5.0},
+		{"7.0 - 2.0 - 3.0", 2.0},
+		{"5.0 * 2.0", 10.0},
+		{"5.0 * 2.0 * 2.0", 20.0},
+		{"10.0 / 5.0", 2.0},
+		{"10.0 / 5.0 / 2.0", 1.0},
+	}
+	runVmTests(t, tests)
+}
+
+func TestIntegerAndFloatArithmetic(t *testing.T) {
+	tests := []vmTestCase{
+		{"1 + 3.0", 4.0},
+		{"2 + 7.0", 9.0},
+		{"7 - 2.0", 5.0},
+		{"7 - 2.0 - 3", 2.0},
+		{"5 * 2.0", 10.0},
+		{"5 * 2 * 2.0", 20.0},
+		{"10 / 5.0", 2.0},
+		{"10 / 5 / 2.0", 1.0},
+	}
+	runVmTests(t, tests)
+}


### PR DESCRIPTION
This pull request introduces support for floating-point arithmetic in the compiler and virtual machine, along with corresponding tests to ensure the new functionality works correctly. The most important changes are as follows:

### Compiler Enhancements:
* Added support for compiling `FloatLiteral` nodes in the `Compile` method of the `compiler.go` file.

### Test Enhancements:
* Updated `testConstants` function in `compiler_test.go` to handle float constants and added a new `testFloatObject` function to verify float objects. [[1]](diffhunk://#diff-cc1616f55ca6edd2c0685642afa94d589da91d1bf06e7b787695782b16dd5145R623-R628) [[2]](diffhunk://#diff-cc1616f55ca6edd2c0685642afa94d589da91d1bf06e7b787695782b16dd5145R1149-R1160)
* Added `TestFloatArithmetic` function in `compiler_test.go` to test various float arithmetic operations.
* Added `TestFloatArithmetic` and `TestIntegerAndFloatArithmetic` functions in `vm_test.go` to test float and mixed integer-float arithmetic operations.

### Virtual Machine Enhancements:
* Enhanced `executeBinaryOperation` in `vm.go` to handle float operations and mixed integer-float operations by converting integers to floats when necessary.
* Added `executeBinaryFloatOperation` function in `vm.go` to perform binary operations on float operands.