### PR TITLE
feat: add 'pop' function to builtins for array manipulation

### DIFF
--- a/evaluator/builtins.go
+++ b/evaluator/builtins.go
@@ -9,5 +9,5 @@ var builtins = map[string]*object.Builtin{
 	"last":  object.GetBuiltinByName("last"),
 	"rest":  object.GetBuiltinByName("rest"),
 	"push":  object.GetBuiltinByName("push"),
-	"pop":  object.GetBuiltinByName("pop"),
+	"pop":   object.GetBuiltinByName("pop"),
 }

--- a/evaluator/builtins.go
+++ b/evaluator/builtins.go
@@ -9,4 +9,5 @@ var builtins = map[string]*object.Builtin{
 	"last":  object.GetBuiltinByName("last"),
 	"rest":  object.GetBuiltinByName("rest"),
 	"push":  object.GetBuiltinByName("push"),
+	"pop":  object.GetBuiltinByName("pop"),
 }

--- a/object/builtins.go
+++ b/object/builtins.go
@@ -126,6 +126,30 @@ var Builtins = []struct {
 		},
 		},
 	},
+	{
+		"pop",
+		&Builtin{Fn: func(args ...Object) Object {
+			if len(args) != 1 {
+				return newError("wrong number of arguments. got=%d, want=1",
+					len(args))
+			}
+			if args[0].Type() != ARRAY_OBJ {
+				return newError("argument to `pop` must be ARRAY, got %s",
+					args[0].Type())
+			}
+
+			arr := args[0].(*Array)
+			length := len(arr.Elements)
+			if length > 0 {
+				newElements := make([]Object, length-1, length-1)
+				copy(newElements, arr.Elements[0:length-1])
+				return &Array{Elements: newElements}
+			}
+
+			return nil
+		},
+		},
+	},
 }
 
 func newError(format string, a ...interface{}) *Error {


### PR DESCRIPTION
This pull request introduces a new built-in function, `pop`, to the language's evaluator and object system. The `pop` function allows users to remove the last element from an array and return a new array without modifying the original. Below are the key changes:

### Addition of the `pop` built-in function:

* **Evaluator integration**:
  - Added the `pop` function to the `builtins` map in `evaluator/builtins.go`, making it available for use in the evaluator.

* **Function definition**:
  - Defined the `pop` function in `object/builtins.go`. It validates the input to ensure it is an array, removes the last element, and returns a new array with the remaining elements. If the array is empty, it returns `nil`.