### PR TITLE
feat: add logical operators (&&, ||) and related functionality

### DIFF
--- a/code/code.go
+++ b/code/code.go
@@ -34,6 +34,8 @@ const (
 	OpBang
 	OpJump
 	OpJumpNotTruthy
+	OpLogicalAnd
+	OpLogicalOr
 	OpNull
 	OpSetGlobal
 	OpGetGlobal
@@ -70,6 +72,8 @@ var definitions = map[Opcode]*Definition{
 	OpBang:             {"OpBang", []int{}},
 	OpJump:             {"OpJump", []int{2}},
 	OpJumpNotTruthy:    {"OpJumpNotTruthy", []int{2}},
+	OpLogicalAnd:       {"OpLogicalAnd", []int{2}},
+	OpLogicalOr:        {"OpLogicalOr", []int{2}},
 	OpNull:             {"OpNull", []int{}},
 	OpGetGlobal:        {"OpGetGlobal", []int{2}},
 	OpSetGlobal:        {"OpSetGlobal", []int{2}},

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -95,6 +95,32 @@ func (c *Compiler) Compile(node ast.Node) error {
 			c.emit(code.OpGreaterThanEqual)
 			return nil
 		}
+		if node.Operator == "&&" {
+			err := c.Compile(node.Left)
+			if err != nil {
+				return err
+			}
+			jumpPos := c.emit(code.OpLogicalAnd, 9999)
+			err = c.Compile(node.Right)
+			if err != nil {
+				return err
+			}
+			c.changeOperand(jumpPos, len(c.currentInstructions()))
+			return nil
+		}
+		if node.Operator == "||" {
+			err := c.Compile(node.Left)
+			if err != nil {
+				return err
+			}
+			jumpPos := c.emit(code.OpLogicalOr, 9999)
+			err = c.Compile(node.Right)
+			if err != nil {
+				return err
+			}
+			c.changeOperand(jumpPos, len(c.currentInstructions()))
+			return nil
+		}
 		err := c.Compile(node.Left)
 		if err != nil {
 			return err

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -162,6 +162,14 @@ func TestEvalBooleanExpression(t *testing.T) {
 		{"(1 < 2) == false", false},
 		{"(1 > 2) == true", false},
 		{"(1 > 2) == false", true},
+		{"true && true", true},
+		{"true && false", false},
+		{"false && true", false},
+		{"false && false", false},
+		{"true || true", true},
+		{"true || false", true},
+		{"false || true", true},
+		{"false || false", false},
 	}
 
 	for _, tt := range tests {
@@ -183,6 +191,33 @@ func testBooleanObject(t *testing.T, obj object.Object, expected bool) bool {
 	}
 
 	return true
+}
+
+func TestLogicalOperators(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected interface{}
+	}{
+		{"1 && 2", 2},
+		{"0 && 2", 2},
+		{"1 || 2", 1},
+		{"0 || 2", 0},
+		{"true && 5", 5},
+		{"false && 5", false},
+		{"true || 5", true},
+		{"false || 5", 5},
+	}
+
+	for _, tt := range tests {
+		evaluated := testEval(tt.input)
+
+		switch expected := tt.expected.(type) {
+		case int:
+			testIntegerObject(t, evaluated, int64(expected))
+		case bool:
+			testBooleanObject(t, evaluated, expected)
+		}
+	}
 }
 
 func TestBangOperator(t *testing.T) {

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -68,6 +68,24 @@ func (l *Lexer) NextToken() token.Token {
 		tok = newToken(token.SLASH, l.ch)
 	case '*':
 		tok = newToken(token.ASTERISK, l.ch)
+	case '&':
+		if l.peekChar() == '&' {
+			ch := l.ch
+			l.readChar()
+			literal := string(ch) + string(l.ch)
+			tok = token.Token{Type: token.AND, Literal: literal}
+		} else {
+			tok = newToken(token.ILLEGAL, l.ch)
+		}
+	case '|':
+		if l.peekChar() == '|' {
+			ch := l.ch
+			l.readChar()
+			literal := string(ch) + string(l.ch)
+			tok = token.Token{Type: token.OR, Literal: literal}
+		} else {
+			tok = newToken(token.ILLEGAL, l.ch)
+		}
 	case '<':
 		if l.peekChar() == '=' {
 			ch := l.ch

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -26,6 +26,8 @@ if (5 < 10) {
 10 != 9;
 5 <= 10;
 15 >= 10;
+true && false;
+true || false;
 
 "foobar"
 "foo bar"
@@ -119,6 +121,14 @@ if (5 < 10) {
 		{token.INT, "15"},
 		{token.GTE, ">="},
 		{token.INT, "10"},
+		{token.SEMICOLON, ";"},
+		{token.TRUE, "true"},
+		{token.AND, "&&"},
+		{token.FALSE, "false"},
+		{token.SEMICOLON, ";"},
+		{token.TRUE, "true"},
+		{token.OR, "||"},
+		{token.FALSE, "false"},
 		{token.SEMICOLON, ";"},
 		{token.STRING, "foobar"},
 		{token.STRING, "foo bar"},

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -12,6 +12,8 @@ import (
 const (
 	_ int = iota
 	LOWEST
+	OR          // ||
+	AND         // &&
 	EQUALS      // ==
 	LESSGREATER // > または <
 	SUM         // +
@@ -24,6 +26,8 @@ const (
 var enableTracing bool = false
 
 var precedences = map[token.TokenType]int{
+	token.OR:       OR,
+	token.AND:      AND,
 	token.EQ:       EQUALS,
 	token.NOT_EQ:   EQUALS,
 	token.LT:       LESSGREATER,
@@ -85,6 +89,8 @@ func New(l *lexer.Lexer) *Parser {
 	p.registerInfix(token.GT, p.parseInfixExpression)
 	p.registerInfix(token.LTE, p.parseInfixExpression)
 	p.registerInfix(token.GTE, p.parseInfixExpression)
+	p.registerInfix(token.AND, p.parseInfixExpression)
+	p.registerInfix(token.OR, p.parseInfixExpression)
 	p.registerInfix(token.LPAREN, p.parseCallExpression)
 	p.registerInfix(token.LBRACKET, p.parseIndexExpression)
 

--- a/token/token.go
+++ b/token/token.go
@@ -26,6 +26,8 @@ const (
 	GT  = ">"
 	LTE = "<="
 	GTE = ">="
+	AND = "&&"
+	OR  = "||"
 	// デリミタ
 	COMMA     = ","
 	SEMICOLON = ";"

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -120,6 +120,30 @@ func (vm *VM) Run() error {
 			if !isTruthy(condition) {
 				vm.currentFrame().ip = pos - 1
 			}
+		case code.OpLogicalAnd:
+			pos := int(code.ReadUint16(ins[ip+1:]))
+			vm.currentFrame().ip += 2
+
+			left := vm.pop()
+			if !isTruthy(left) {
+				vm.currentFrame().ip = pos - 1
+				err := vm.push(left)
+				if err != nil {
+					return err
+				}
+			}
+		case code.OpLogicalOr:
+			pos := int(code.ReadUint16(ins[ip+1:]))
+			vm.currentFrame().ip += 2
+
+			left := vm.pop()
+			if isTruthy(left) {
+				vm.currentFrame().ip = pos - 1
+				err := vm.push(left)
+				if err != nil {
+					return err
+				}
+			}
 		case code.OpNull:
 			err := vm.push(Null)
 			if err != nil {


### PR DESCRIPTION
This pull request introduces support for logical operators (`&&` and `||`) in the language's compiler, evaluator, lexer, parser, and virtual machine. It also includes corresponding tests to ensure the correctness of the implementation. Below are the most important changes grouped by theme:

### Compiler and Virtual Machine Enhancements:
* Added new opcodes `OpLogicalAnd` and `OpLogicalOr` to the `code` package to handle logical operations. (`code/code.go`: [[1]](diffhunk://#diff-2ad350013d16e8e5c021ee6f046700bb0b8249a3baa1fe88c79aac3c06c214bbR37-R38) [[2]](diffhunk://#diff-2ad350013d16e8e5c021ee6f046700bb0b8249a3baa1fe88c79aac3c06c214bbR75-R76)
* Updated the `Compiler` to emit instructions for `&&` and `||` operators, including operand adjustments for jump positions. (`compiler/compiler.go`: [compiler/compiler.goR98-R123](diffhunk://#diff-d3cde2dec4b7c2263747b17d43f704418e6657b49583254628bcad1d1052471bR98-R123))
* Modified the `VM` to execute `OpLogicalAnd` and `OpLogicalOr` instructions, managing truthiness and jump positions accordingly. (`vm/vm.go`: [vm/vm.goR123-R146](diffhunk://#diff-c087fa7dffa5d472e6b7b59eb8f8bafd4208832487a1429e0fcfc38a9fe05167R123-R146))

### Evaluator Enhancements:
* Added logic to evaluate `&&` and `||` operators in the `evalLogicalInfixExpression` function, ensuring short-circuit evaluation. (`evaluator/evaluator.go`: [[1]](diffhunk://#diff-80846a8582a8797b53b71827455b4154e1c988766db890ebf9ca1403738fc8a5R32-R34) [[2]](diffhunk://#diff-80846a8582a8797b53b71827455b4154e1c988766db890ebf9ca1403738fc8a5R438-R459)

### Lexer and Parser Updates:
* Updated the `Lexer` to tokenize `&&` and `||` as valid operators. (`lexer/lexer.go`: [lexer/lexer.goR71-R88](diffhunk://#diff-632c407e6b02eeb29f8248cc09fe9411bea21d7e4821f206186162aec10726faR71-R88))
* Enhanced the `Parser` to handle precedence and parsing of `&&` and `||` operators. (`parser/parser.go`: [[1]](diffhunk://#diff-e7aabff4498aa61c581fe6fd5c90c50da24b02b88f32d75238a5dc37edaaa794R15-R16) [[2]](diffhunk://#diff-e7aabff4498aa61c581fe6fd5c90c50da24b02b88f32d75238a5dc37edaaa794R29-R30) [[3]](diffhunk://#diff-e7aabff4498aa61c581fe6fd5c90c50da24b02b88f32d75238a5dc37edaaa794R92-R93)

### Testing:
* Added tests for logical operators in the `Evaluator`, ensuring correct behavior for various combinations of truthy and falsy values. (`evaluator/evaluator_test.go`: [[1]](diffhunk://#diff-1415ede581c457f23a734ff3b275cd90b94b6aaebb5200cf02416985c60e9a3bR165-R172) [[2]](diffhunk://#diff-1415ede581c457f23a734ff3b275cd90b94b6aaebb5200cf02416985c60e9a3bR196-R222)
* Updated lexer tests to include tokenization of `&&` and `||`. (`lexer/lexer_test.go`: [[1]](diffhunk://#diff-5eda3506f4a5446c39cb9cf534eb0d2ac6edbcdda2010a188cf7520d66de3a7bR29-R30) [[2]](diffhunk://#diff-5eda3506f4a5446c39cb9cf534eb0d2ac6edbcdda2010a188cf7520d66de3a7bR125-R132)