### PR TITLE
feat: add support for loop statements (for, while) and control statements (break, continue)

### DIFF
--- a/ast/ast.go
+++ b/ast/ast.go
@@ -384,3 +384,77 @@ type FloatLiteral struct {
 func (fl *FloatLiteral) expressionNode()      {}
 func (fl *FloatLiteral) TokenLiteral() string { return fl.Token.Literal }
 func (fl *FloatLiteral) String() string       { return fl.Token.Literal }
+
+type ForStatement struct {
+	Token     token.Token // The 'for' token
+	Init      Statement   // Initialization statement (optional)
+	Condition Expression  // Loop condition (optional)
+	Update    Statement   // Update statement (optional)
+	Body      *BlockStatement
+}
+
+func (fs *ForStatement) statementNode()       {}
+func (fs *ForStatement) TokenLiteral() string { return fs.Token.Literal }
+
+func (fs *ForStatement) String() string {
+	var out bytes.Buffer
+
+	out.WriteString("for (")
+	if fs.Init != nil {
+		out.WriteString(fs.Init.String())
+	}
+	out.WriteString("; ")
+	if fs.Condition != nil {
+		out.WriteString(fs.Condition.String())
+	}
+	out.WriteString("; ")
+	if fs.Update != nil {
+		out.WriteString(fs.Update.String())
+	}
+	out.WriteString(") ")
+	out.WriteString(fs.Body.String())
+
+	return out.String()
+}
+
+type WhileStatement struct {
+	Token     token.Token // The 'while' token
+	Condition Expression
+	Body      *BlockStatement
+}
+
+func (ws *WhileStatement) statementNode()       {}
+func (ws *WhileStatement) TokenLiteral() string { return ws.Token.Literal }
+
+func (ws *WhileStatement) String() string {
+	var out bytes.Buffer
+
+	out.WriteString("while (")
+	out.WriteString(ws.Condition.String())
+	out.WriteString(") ")
+	out.WriteString(ws.Body.String())
+
+	return out.String()
+}
+
+type BreakStatement struct {
+	Token token.Token // The 'break' token
+}
+
+func (bs *BreakStatement) statementNode()       {}
+func (bs *BreakStatement) TokenLiteral() string { return bs.Token.Literal }
+
+func (bs *BreakStatement) String() string {
+	return bs.Token.Literal + ";"
+}
+
+type ContinueStatement struct {
+	Token token.Token // The 'continue' token
+}
+
+func (cs *ContinueStatement) statementNode()       {}
+func (cs *ContinueStatement) TokenLiteral() string { return cs.Token.Literal }
+
+func (cs *ContinueStatement) String() string {
+	return cs.Token.Literal + ";"
+}

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -591,3 +591,20 @@ func TestAssignmentExpressions(t *testing.T) {
 		testIntegerObject(t, evaluated, tt.expected)
 	}
 }
+
+func TestLoopStatements(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected int64
+	}{
+		{`let sum = 0; for (let i = 1; i <= 3; i += 1) { sum += i; } sum;`, 6},
+		{`let sum = 0; let i = 1; while (i <= 3) { sum += i; i += 1; } sum;`, 6},
+		{`let sum = 0; for (let i = 1; i <= 5; i += 1) { if (i == 3) { continue; } sum += i; } sum;`, 12},
+		{`let sum = 0; for (let i = 1; i <= 10; i += 1) { if (i == 4) { break; } sum += i; } sum;`, 6},
+	}
+
+	for _, tt := range tests {
+		evaluated := testEval(tt.input)
+		testIntegerObject(t, evaluated, tt.expected)
+	}
+}

--- a/object/object.go
+++ b/object/object.go
@@ -30,6 +30,9 @@ const (
 	CLOSURE_OBJ = "CLOSURE"
 
 	FLOAT_OBJ = "FLOAT"
+
+	BREAK_OBJ    = "BREAK"
+	CONTINUE_OBJ = "CONTINUE"
 )
 
 type ObjectType string
@@ -215,3 +218,13 @@ type Float struct {
 
 func (f *Float) Type() ObjectType { return FLOAT_OBJ }
 func (f *Float) Inspect() string  { return fmt.Sprintf("%f", f.Value) }
+
+type Break struct{}
+
+func (b *Break) Type() ObjectType { return BREAK_OBJ }
+func (b *Break) Inspect() string  { return "break" }
+
+type Continue struct{}
+
+func (c *Continue) Type() ObjectType { return CONTINUE_OBJ }
+func (c *Continue) Inspect() string  { return "continue" }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -135,6 +135,14 @@ func (p *Parser) parseStatement() ast.Statement {
 		return p.parseLetStatement()
 	case token.RETURN:
 		return p.parseReturnStatement()
+	case token.FOR:
+		return p.parseForStatement()
+	case token.WHILE:
+		return p.parseWhileStatement()
+	case token.BREAK:
+		return p.parseBreakStatement()
+	case token.CONTINUE:
+		return p.parseContinueStatement()
 	default:
 		return p.parseExpressionStatement()
 	}
@@ -574,4 +582,99 @@ func (p *Parser) parseAssignmentExpression() ast.Expression {
 	assignExpr.Value = p.parseExpression(LOWEST)
 
 	return assignExpr
+}
+
+func (p *Parser) parseForStatement() *ast.ForStatement {
+	stmt := &ast.ForStatement{Token: p.curToken}
+
+	if !p.expectPeek(token.LPAREN) {
+		return nil
+	}
+
+	// Parse initialization (optional)
+	if !p.peekTokenIs(token.SEMICOLON) {
+		p.nextToken()
+		stmt.Init = p.parseStatement()
+		// Skip semicolon if it exists after the statement
+		if p.peekTokenIs(token.SEMICOLON) {
+			p.nextToken()
+		}
+	} else {
+		p.nextToken() // consume the semicolon
+	}
+
+	// Parse condition (optional)
+	if !p.peekTokenIs(token.SEMICOLON) {
+		p.nextToken()
+		stmt.Condition = p.parseExpression(LOWEST)
+	}
+
+	if !p.expectPeek(token.SEMICOLON) {
+		return nil
+	}
+
+	// Parse update (optional)
+	if !p.peekTokenIs(token.RPAREN) {
+		p.nextToken()
+		stmt.Update = p.parseStatement()
+		// Skip semicolon if it exists after the statement
+		if p.peekTokenIs(token.SEMICOLON) {
+			p.nextToken()
+		}
+	}
+
+	if !p.expectPeek(token.RPAREN) {
+		return nil
+	}
+
+	if !p.expectPeek(token.LBRACE) {
+		return nil
+	}
+
+	stmt.Body = p.parseBlockStatement()
+
+	return stmt
+}
+
+func (p *Parser) parseWhileStatement() *ast.WhileStatement {
+	stmt := &ast.WhileStatement{Token: p.curToken}
+
+	if !p.expectPeek(token.LPAREN) {
+		return nil
+	}
+
+	p.nextToken()
+	stmt.Condition = p.parseExpression(LOWEST)
+
+	if !p.expectPeek(token.RPAREN) {
+		return nil
+	}
+
+	if !p.expectPeek(token.LBRACE) {
+		return nil
+	}
+
+	stmt.Body = p.parseBlockStatement()
+
+	return stmt
+}
+
+func (p *Parser) parseBreakStatement() *ast.BreakStatement {
+	stmt := &ast.BreakStatement{Token: p.curToken}
+
+	if p.peekTokenIs(token.SEMICOLON) {
+		p.nextToken()
+	}
+
+	return stmt
+}
+
+func (p *Parser) parseContinueStatement() *ast.ContinueStatement {
+	stmt := &ast.ContinueStatement{Token: p.curToken}
+
+	if p.peekTokenIs(token.SEMICOLON) {
+		p.nextToken()
+	}
+
+	return stmt
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -944,3 +944,32 @@ func checkParserErrors(t *testing.T, p *Parser) {
 	}
 	t.FailNow()
 }
+
+func TestLoopStatements(t *testing.T) {
+	tests := []struct {
+		input        string
+		expectedType string
+	}{
+		{"for (let i = 0; i < 3; i += 1) { puts(i); }", "*ast.ForStatement"},
+		{"while (x > 0) { x -= 1; }", "*ast.WhileStatement"},
+		{"break;", "*ast.BreakStatement"},
+		{"continue;", "*ast.ContinueStatement"},
+	}
+
+	for _, tt := range tests {
+		l := lexer.New(tt.input)
+		p := New(l)
+		program := p.ParseProgram()
+		checkParserErrors(t, p)
+
+		if len(program.Statements) != 1 {
+			t.Fatalf("program has not enough statements. got=%d",
+				len(program.Statements))
+		}
+
+		stmt := program.Statements[0]
+		if fmt.Sprintf("%T", stmt) != tt.expectedType {
+			t.Errorf("statement is not %s. got=%T", tt.expectedType, stmt)
+		}
+	}
+}

--- a/token/token.go
+++ b/token/token.go
@@ -47,6 +47,12 @@ const (
 	EQ       = "=="
 	NOT_EQ   = "!="
 
+	// ループキーワード
+	FOR      = "FOR"
+	WHILE    = "WHILE"
+	BREAK    = "BREAK"
+	CONTINUE = "CONTINUE"
+
 	// 代入演算子
 	PLUS_ASSIGN     = "+="
 	MINUS_ASSIGN    = "-="
@@ -62,13 +68,17 @@ const (
 )
 
 var keywords = map[string]TokenType{
-	"fn":     FUNCTION,
-	"let":    LET,
-	"true":   TRUE,
-	"false":  FALSE,
-	"if":     IF,
-	"else":   ELSE,
-	"return": RETURN,
+	"fn":       FUNCTION,
+	"let":      LET,
+	"true":     TRUE,
+	"false":    FALSE,
+	"if":       IF,
+	"else":     ELSE,
+	"return":   RETURN,
+	"for":      FOR,
+	"while":    WHILE,
+	"break":    BREAK,
+	"continue": CONTINUE,
 }
 
 func LookupIdent(ident string) TokenType {


### PR DESCRIPTION
This pull request introduces support for loop constructs (`for`, `while`) and control flow statements (`break`, `continue`) in the language, including their parsing, evaluation, and compilation. The changes span multiple components of the codebase, including the AST, parser, compiler, evaluator, and associated tests.

### Language Features Added:

#### Loop Constructs:
* Added `ForStatement` and `WhileStatement` types to the AST, enabling representation of `for` and `while` loops. These include optional initialization, condition, and update statements for `ForStatement`. (`ast/ast.go`)
* Implemented parsing logic for `for` and `while` loops in the parser, including handling of their respective syntax. (`parser/parser.go`)

#### Control Flow Statements:
* Added `BreakStatement` and `ContinueStatement` types to the AST for `break` and `continue` statements. (`ast/ast.go`)
* Implemented parsing logic for `break` and `continue` statements in the parser, ensuring proper handling of these keywords. (`parser/parser.go`)

### Evaluation Logic:
* Added evaluation logic for `ForStatement` and `WhileStatement`, including support for loop scope and handling `break` and `continue` statements. (`evaluator/evaluator.go`)
* Updated `evalBlockStatement` to correctly handle `BREAK_OBJ` and `CONTINUE_OBJ` types, ensuring proper control flow within loops. (`evaluator/evaluator.go`)

### Compilation Logic:
* Implemented compilation logic for `ForStatement` and `WhileStatement`, including handling of initialization, condition checks, body execution, updates, and loop jumps. (`compiler/compiler.go`)
* Added placeholders for `break` and `continue` statements in the compiler, with error messages indicating their current lack of support. (`compiler/compiler.go`)

### Tests:
* Added tests for loop constructs and control flow statements in both the evaluator and parser test suites to ensure correctness. (`evaluator/evaluator_test.go`, `parser/parser_test.go`) [[1]](diffhunk://#diff-1415ede581c457f23a734ff3b275cd90b94b6aaebb5200cf02416985c60e9a3bR594-R610) [[2]](diffhunk://#diff-6eaacb6a6fa7a8b6851fa3bc9917a3cfc6a7a3e191069b6d59ae5385b9beb6faR947-R975)

### Token and Object Updates:
* Added new token types (`FOR`, `WHILE`, `BREAK`, `CONTINUE`) and updated the keyword lookup map to recognize these keywords. (`token/token.go`) [[1]](diffhunk://#diff-33bf6304dd970a085d3e7819ae65390a9c7fd1fe65eee30f0dc82021ff6975e0R50-R55) [[2]](diffhunk://#diff-33bf6304dd970a085d3e7819ae65390a9c7fd1fe65eee30f0dc82021ff6975e0R78-R81)
* Introduced `Break` and `Continue` object types to represent `break` and `continue` statements during evaluation. (`object/object.go`)