### PR TITLE
feat: add support for single-line and multi-line comments in lexer

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -290,7 +290,7 @@ func (l *Lexer) readMultiLineComment() string {
 	position := l.position
 	l.readChar() // skip '/'
 	l.readChar() // skip '*'
-	
+
 	for {
 		if l.ch == 0 {
 			// Unterminated comment - return what we have

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -163,3 +163,115 @@ true || false;
 		}
 	}
 }
+
+func TestComments(t *testing.T) {
+	input := `// This is a single line comment
+let five = 5; // Another single line comment
+/* This is a 
+   multi-line comment */
+let ten = 10;
+/* Another multi-line comment */`
+
+	tests := []struct {
+		expectedType    token.TokenType
+		expectedLiteral string
+	}{
+		{token.LET, "let"},
+		{token.IDENT, "five"},
+		{token.ASSIGN, "="},
+		{token.INT, "5"},
+		{token.SEMICOLON, ";"},
+		{token.LET, "let"},
+		{token.IDENT, "ten"},
+		{token.ASSIGN, "="},
+		{token.INT, "10"},
+		{token.SEMICOLON, ";"},
+		{token.EOF, ""},
+	}
+
+	l := New(input)
+
+	for i, tt := range tests {
+		tok := l.NextToken()
+
+		if tok.Type != tt.expectedType {
+			t.Fatalf("tests[%d] - tokentype wrong. expected=%q, got=%q",
+				i, tt.expectedType, tok.Type)
+		}
+
+		if tok.Literal != tt.expectedLiteral {
+			t.Fatalf("tests[%d] - literal wrong. expected=%q, got=%q",
+				i, tt.expectedLiteral, tok.Literal)
+		}
+	}
+}
+
+func TestSingleLineComment(t *testing.T) {
+	input := `// This is a single line comment
+// Another comment
+let x = 5;`
+
+	expected := []struct {
+		expectedType    token.TokenType
+		expectedLiteral string
+	}{
+		{token.LET, "let"},
+		{token.IDENT, "x"},
+		{token.ASSIGN, "="},
+		{token.INT, "5"},
+		{token.SEMICOLON, ";"},
+		{token.EOF, ""},
+	}
+
+	l := New(input)
+
+	for i, tt := range expected {
+		tok := l.NextToken()
+
+		if tok.Type != tt.expectedType {
+			t.Fatalf("tests[%d] - tokentype wrong. expected=%q, got=%q",
+				i, tt.expectedType, tok.Type)
+		}
+
+		if tok.Literal != tt.expectedLiteral {
+			t.Fatalf("tests[%d] - literal wrong. expected=%q, got=%q",
+				i, tt.expectedLiteral, tok.Literal)
+		}
+	}
+}
+
+func TestMultiLineComment(t *testing.T) {
+	input := `/* This is a 
+   multi-line comment 
+   that spans multiple lines */
+let x = 5;
+/* Another multi-line comment */`
+
+	expected := []struct {
+		expectedType    token.TokenType
+		expectedLiteral string
+	}{
+		{token.LET, "let"},
+		{token.IDENT, "x"},
+		{token.ASSIGN, "="},
+		{token.INT, "5"},
+		{token.SEMICOLON, ";"},
+		{token.EOF, ""},
+	}
+
+	l := New(input)
+
+	for i, tt := range expected {
+		tok := l.NextToken()
+
+		if tok.Type != tt.expectedType {
+			t.Fatalf("tests[%d] - tokentype wrong. expected=%q, got=%q",
+				i, tt.expectedType, tok.Type)
+		}
+
+		if tok.Literal != tt.expectedLiteral {
+			t.Fatalf("tests[%d] - literal wrong. expected=%q, got=%q",
+				i, tt.expectedLiteral, tok.Literal)
+		}
+	}
+}

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -75,9 +75,10 @@ func Start(in io.Reader, out io.Writer) {
 		// io.WriteString(out, stackTop.Inspect())
 		// io.WriteString(out, "\n")
 		lastPopped := machine.LastPoppedStackElem()
-		io.WriteString(out, lastPopped.Inspect())
-		io.WriteString(out, "\n")
-
+		if lastPopped != nil {
+			io.WriteString(out, lastPopped.Inspect())
+			io.WriteString(out, "\n")
+		}
 	}
 }
 

--- a/token/token.go
+++ b/token/token.go
@@ -65,6 +65,9 @@ const (
 	RBRACKET = "]"
 
 	COLON = ":"
+
+	// コメント
+	COMMENT = "COMMENT"
 )
 
 var keywords = map[string]TokenType{


### PR DESCRIPTION
This pull request enhances the lexer functionality to handle comments and adds corresponding tests to ensure correctness. It also includes minor improvements to the REPL output handling. The most significant changes involve adding support for single-line and multi-line comments in the lexer and updating the token definitions.

### Lexer Enhancements:
* Added support for skipping single-line (`//`) and multi-line (`/* */`) comments in the `Lexer` class. This includes methods `readSingleLineComment`, `readMultiLineComment`, and `hasValidMultiLineComment`. [[1]](diffhunk://#diff-632c407e6b02eeb29f8248cc09fe9411bea21d7e4821f206186162aec10726faR46-R55) [[2]](diffhunk://#diff-632c407e6b02eeb29f8248cc09fe9411bea21d7e4821f206186162aec10726faR245-R257) [[3]](diffhunk://#diff-632c407e6b02eeb29f8248cc09fe9411bea21d7e4821f206186162aec10726faR268-R307)
* Introduced a new token type `COMMENT` to represent comments in the lexer.

### Testing:
* Added unit tests in `lexer_test.go` to verify the handling of single-line and multi-line comments, ensuring they are properly skipped during tokenization.

### REPL Improvements:
* Fixed a potential nil pointer issue in the REPL output by adding a check for `lastPopped` before calling its `Inspect` method.