### PR TITLE
fix: add nil checks for arguments in built-in functions and operations

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -209,7 +209,7 @@ func (l *Lexer) readIdentifier() string {
 }
 
 func isLetter(ch byte) bool {
-	return 'a' <= ch && ch <= 'z' || 'A' <= ch && ch <= 'X' || ch == '_'
+	return 'a' <= ch && ch <= 'z' || 'A' <= ch && ch <= 'Z' || ch == '_'
 }
 
 func (l *Lexer) readNumber() string {

--- a/object/builtins.go
+++ b/object/builtins.go
@@ -42,6 +42,9 @@ var Builtins = []struct {
 				return newError("wrong number of arguments. got=%d, want=1",
 					len(args))
 			}
+			if args[0] == nil {
+				return newError("argument to `first` cannot be nil")
+			}
 			if args[0].Type() != ARRAY_OBJ {
 				return newError("argument to `first` must be ARRAY, got %s",
 					args[0].Type())
@@ -64,6 +67,9 @@ var Builtins = []struct {
 				return newError("wrong number of arguments. got=%d, want=1",
 					len(args))
 			}
+			if args[0] == nil {
+				return newError("argument to `last` cannot be nil")
+			}
 			if args[0].Type() != ARRAY_OBJ {
 				return newError("argument to `last` must be ARRAY, got %s",
 					args[0].Type())
@@ -85,6 +91,9 @@ var Builtins = []struct {
 			if len(args) != 1 {
 				return newError("wrong number of arguments. got=%d, want=1",
 					len(args))
+			}
+			if args[0] == nil {
+				return newError("argument to `rest` cannot be nil")
 			}
 			if args[0].Type() != ARRAY_OBJ {
 				return newError("argument to `rest` must be ARRAY, got %s",
@@ -110,6 +119,9 @@ var Builtins = []struct {
 				return newError("wrong number of arguments. got=%d, want=2",
 					len(args))
 			}
+			if args[0] == nil {
+				return newError("argument to `push` cannot be nil")
+			}
 			if args[0].Type() != ARRAY_OBJ {
 				return newError("argument to `push` must be ARRAY, got %s",
 					args[0].Type())
@@ -132,6 +144,9 @@ var Builtins = []struct {
 			if len(args) != 1 {
 				return newError("wrong number of arguments. got=%d, want=1",
 					len(args))
+			}
+			if args[0] == nil {
+				return newError("argument to `pop` cannot be nil")
 			}
 			if args[0].Type() != ARRAY_OBJ {
 				return newError("argument to `pop` must be ARRAY, got %s",

--- a/vm/frame.go
+++ b/vm/frame.go
@@ -20,5 +20,8 @@ func NewFrame(cl *object.Closure, basePointer int) *Frame {
 }
 
 func (f *Frame) Instructions() code.Instructions {
+	if f.cl == nil || f.cl.Fn == nil {
+		return nil
+	}
 	return f.cl.Fn.Instructions
 }

--- a/vm/vm.go
+++ b/vm/vm.go
@@ -279,6 +279,9 @@ func (vm *VM) push(o object.Object) error {
 }
 
 func (vm *VM) pop() object.Object {
+	if vm.sp == 0 {
+		return nil
+	}
 	o := vm.stack[vm.sp-1]
 	vm.sp--
 	return o
@@ -312,6 +315,9 @@ func (vm *VM) executeBinaryOperation(op code.Opcode) error {
 }
 
 func (vm *VM) executeBinaryIntegerOperation(op code.Opcode, left, right object.Object) error {
+	if left == nil || right == nil {
+		return fmt.Errorf("nil operand in binary integer operation")
+	}
 	leftValue := left.(*object.Integer).Value
 	rightValue := right.(*object.Integer).Value
 
@@ -334,6 +340,9 @@ func (vm *VM) executeBinaryIntegerOperation(op code.Opcode, left, right object.O
 }
 
 func (vm *VM) executeBinaryFloatOperation(op code.Opcode, left, right object.Object) error {
+	if left == nil || right == nil {
+		return fmt.Errorf("nil operand in binary float operation")
+	}
 	leftValue := left.(*object.Float).Value
 	rightValue := right.(*object.Float).Value
 	var result float64
@@ -386,6 +395,9 @@ func (vm *VM) executeComparison(op code.Opcode) error {
 }
 
 func (vm *VM) executeIntegerComparison(op code.Opcode, left, right object.Object) error {
+	if left == nil || right == nil {
+		return fmt.Errorf("nil operand in integer comparison")
+	}
 	leftValue := left.(*object.Integer).Value
 	rightValue := right.(*object.Integer).Value
 
@@ -426,6 +438,9 @@ func (vm *VM) executeBangOperator() error {
 
 func (vm *VM) executeMinusOperator() error {
 	operand := vm.pop()
+	if operand == nil {
+		return fmt.Errorf("nil operand in minus operation")
+	}
 	if operand.Type() != object.INTEGER_OBJ {
 		return fmt.Errorf("unsupported type for negation: %s", operand.Type())
 	}
@@ -489,6 +504,9 @@ func isTruthy(obj object.Object) bool {
 }
 
 func (vm *VM) executeArrayIndex(array, index object.Object) error {
+	if array == nil || index == nil {
+		return fmt.Errorf("nil operand in array index operation")
+	}
 	arrayObject := array.(*object.Array)
 	i := index.(*object.Integer).Value
 	max := int64(len(arrayObject.Elements) - 1)
@@ -499,6 +517,9 @@ func (vm *VM) executeArrayIndex(array, index object.Object) error {
 }
 
 func (vm *VM) executeHashIndex(hash, index object.Object) error {
+	if hash == nil || index == nil {
+		return fmt.Errorf("nil operand in hash index operation")
+	}
 	hashObject := hash.(*object.Hash)
 	key, ok := index.(object.Hashable)
 	if !ok {
@@ -512,6 +533,9 @@ func (vm *VM) executeHashIndex(hash, index object.Object) error {
 }
 
 func (vm *VM) currentFrame() *Frame {
+	if vm.frameIndex == 0 {
+		return nil
+	}
 	return vm.frames[vm.frameIndex-1]
 }
 


### PR DESCRIPTION
This pull request introduces several improvements to enhance error handling and correctness in the lexer, built-ins, and virtual machine (VM) components of the codebase. The most significant changes involve adding checks for `nil` values to prevent runtime errors and fixing a bug in the lexer logic for identifying uppercase letters.

### Lexer improvements:
* Fixed a bug in `isLetter` logic to correctly identify all uppercase letters (`A` through `Z`) in `lexer/lexer.go`. Previously, the range only went up to `X`.

### Built-ins error handling:
* Added checks to ensure arguments passed to built-in functions (`first`, `last`, `rest`, `push`, and `pop`) are not `nil`. This prevents operations on invalid or uninitialized values in `object/builtins.go`. [[1]](diffhunk://#diff-b99e4c5d440bbba7f3d8e3cef52ce865244a03cd8932f6c37b2b50e16f805d05R45-R47) [[2]](diffhunk://#diff-b99e4c5d440bbba7f3d8e3cef52ce865244a03cd8932f6c37b2b50e16f805d05R70-R72) [[3]](diffhunk://#diff-b99e4c5d440bbba7f3d8e3cef52ce865244a03cd8932f6c37b2b50e16f805d05R95-R97) [[4]](diffhunk://#diff-b99e4c5d440bbba7f3d8e3cef52ce865244a03cd8932f6c37b2b50e16f805d05R122-R124) [[5]](diffhunk://#diff-b99e4c5d440bbba7f3d8e3cef52ce865244a03cd8932f6c37b2b50e16f805d05R148-R150)

### Virtual machine (VM) robustness:
* Added `nil` checks in various VM operations, including binary operations, comparisons, array/hash indexing, and unary operations, to avoid runtime errors when operands are uninitialized or invalid in `vm/vm.go`. [[1]](diffhunk://#diff-c087fa7dffa5d472e6b7b59eb8f8bafd4208832487a1429e0fcfc38a9fe05167R318-R320) [[2]](diffhunk://#diff-c087fa7dffa5d472e6b7b59eb8f8bafd4208832487a1429e0fcfc38a9fe05167R343-R345) [[3]](diffhunk://#diff-c087fa7dffa5d472e6b7b59eb8f8bafd4208832487a1429e0fcfc38a9fe05167R398-R400) [[4]](diffhunk://#diff-c087fa7dffa5d472e6b7b59eb8f8bafd4208832487a1429e0fcfc38a9fe05167R441-R443) [[5]](diffhunk://#diff-c087fa7dffa5d472e6b7b59eb8f8bafd4208832487a1429e0fcfc38a9fe05167R507-R509) [[6]](diffhunk://#diff-c087fa7dffa5d472e6b7b59eb8f8bafd4208832487a1429e0fcfc38a9fe05167R520-R522)
* Prevented potential `nil` dereferencing in frame-related operations by adding checks in `vm/frame.go` and `vm/vm.go`. [[1]](diffhunk://#diff-9f3aa0323c5a8bd85a75c1b192940c16e7b0364a8fbf587596ee5669d9eb8338R23-R25) [[2]](diffhunk://#diff-c087fa7dffa5d472e6b7b59eb8f8bafd4208832487a1429e0fcfc38a9fe05167R536-R538)