### PR TITLE
String intering

### DIFF
--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -10,14 +10,14 @@ type Lexer struct {
 	position     int
 	readPosition int
 	ch           byte
-	
+
 	// String interning table for literals
 	stringInternTable map[string]string
 }
 
 func New(input string) *Lexer {
 	l := &Lexer{
-		input: input,
+		input:             input,
 		stringInternTable: make(map[string]string),
 	}
 	// l.position = 0, l.readPosition = 0, l.ch = 0にして初期化

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -10,13 +10,28 @@ type Lexer struct {
 	position     int
 	readPosition int
 	ch           byte
+	
+	// String interning table for literals
+	stringInternTable map[string]string
 }
 
 func New(input string) *Lexer {
-	l := &Lexer{input: input}
+	l := &Lexer{
+		input: input,
+		stringInternTable: make(map[string]string),
+	}
 	// l.position = 0, l.readPosition = 0, l.ch = 0にして初期化
 	l.readChar()
 	return l
+}
+
+// internString interns a string to reduce memory usage for duplicate literals
+func (l *Lexer) internString(s string) string {
+	if interned, exists := l.stringInternTable[s]; exists {
+		return interned
+	}
+	l.stringInternTable[s] = s
+	return s
 }
 
 func (l *Lexer) readChar() {
@@ -205,7 +220,8 @@ func (l *Lexer) readIdentifier() string {
 	for isLetter(l.ch) {
 		l.readChar()
 	}
-	return l.input[position:l.position]
+	identifier := l.input[position:l.position]
+	return l.internString(identifier)
 }
 
 func isLetter(ch byte) bool {
@@ -263,7 +279,8 @@ func (l *Lexer) readString() string {
 			break
 		}
 	}
-	return l.input[position:l.position]
+	stringLiteral := l.input[position:l.position]
+	return l.internString(stringLiteral)
 }
 
 func (l *Lexer) readSingleLineComment() string {


### PR DESCRIPTION
This pull request introduces a string interning mechanism in the `Lexer` struct to optimize memory usage by reducing duplication of string literals. The changes primarily focus on adding a string interning table and modifying methods to utilize this feature.

### String interning enhancements:

* [`lexer/lexer.go`](diffhunk://#diff-632c407e6b02eeb29f8248cc09fe9411bea21d7e4821f206186162aec10726faR13-R36): Added a `stringInternTable` field to the `Lexer` struct to store interned strings and initialized it in the `New` function. This enables efficient reuse of string literals.
* [`lexer/lexer.go`](diffhunk://#diff-632c407e6b02eeb29f8248cc09fe9411bea21d7e4821f206186162aec10726faR13-R36): Introduced the `internString` method in the `Lexer` struct to handle string interning. This method checks if a string is already interned and returns the interned version or adds it to the table if not.

### Updates to string handling methods:

* [`lexer/lexer.go`](diffhunk://#diff-632c407e6b02eeb29f8248cc09fe9411bea21d7e4821f206186162aec10726faL208-R224): Modified the `readIdentifier` method to intern identifiers before returning them, ensuring duplicate identifiers share the same memory.
* [`lexer/lexer.go`](diffhunk://#diff-632c407e6b02eeb29f8248cc09fe9411bea21d7e4821f206186162aec10726faL266-R283): Updated the `readString` method to intern string literals before returning them, reducing memory usage for duplicate strings.