### PR TITLE
feat: allow digits in identifiers and add corresponding tests

### DIFF
--- a/examples/regex.monkey
+++ b/examples/regex.monkey
@@ -1,0 +1,33 @@
+// Regular expression examples
+// This demonstrates regex pattern matching and manipulation
+
+puts("Regular Expression Examples:");
+
+let pattern = regex("[0-9]+");
+let text = "I have 42 apples and 7 oranges";
+
+puts("Original text:");
+puts(text);
+
+puts("Match numbers:");
+puts(match(pattern, text));
+
+puts("Replace numbers with X:");
+let replaced = replace(text, pattern, "X");
+puts(replaced);
+
+puts("Split by numbers:");
+let parts = regex_split(text, pattern);
+puts(parts);
+
+// Simple pattern matching
+puts("Pattern matching:");
+let word_pattern = regex("world");
+let text1 = "hello world";
+let text2 = "helloearth";
+
+puts(text1);
+puts(match(word_pattern, text1));
+
+puts(text2);
+puts(match(word_pattern, text2));

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -217,7 +217,7 @@ func newToken(tokenType token.TokenType, ch byte) token.Token {
 
 func (l *Lexer) readIdentifier() string {
 	position := l.position
-	for isLetter(l.ch) {
+	for isLetter(l.ch) || isDigit(l.ch) {
 		l.readChar()
 	}
 	identifier := l.input[position:l.position]

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -241,8 +241,8 @@ let x = 5;`
 }
 
 func TestMultiLineComment(t *testing.T) {
-	input := `/* This is a 
-   multi-line comment 
+	input := `/* This is a
+   multi-line comment
    that spans multiple lines */
 let x = 5;
 /* Another multi-line comment */`
@@ -262,6 +262,63 @@ let x = 5;
 	l := New(input)
 
 	for i, tt := range expected {
+		tok := l.NextToken()
+
+		if tok.Type != tt.expectedType {
+			t.Fatalf("tests[%d] - tokentype wrong. expected=%q, got=%q",
+				i, tt.expectedType, tok.Type)
+		}
+
+		if tok.Literal != tt.expectedLiteral {
+			t.Fatalf("tests[%d] - literal wrong. expected=%q, got=%q",
+				i, tt.expectedLiteral, tok.Literal)
+		}
+	}
+}
+
+func TestIdentifiersWithDigits(t *testing.T) {
+	input := `let text1 = "hello";
+let var2name = 10;
+let _x3 = text1;
+let abc123def = 42;
+123;
+3.14;
+`
+
+	tests := []struct {
+		expectedType    token.TokenType
+		expectedLiteral string
+	}{
+		{token.LET, "let"},
+		{token.IDENT, "text1"},
+		{token.ASSIGN, "="},
+		{token.STRING, "hello"},
+		{token.SEMICOLON, ";"},
+		{token.LET, "let"},
+		{token.IDENT, "var2name"},
+		{token.ASSIGN, "="},
+		{token.INT, "10"},
+		{token.SEMICOLON, ";"},
+		{token.LET, "let"},
+		{token.IDENT, "_x3"},
+		{token.ASSIGN, "="},
+		{token.IDENT, "text1"},
+		{token.SEMICOLON, ";"},
+		{token.LET, "let"},
+		{token.IDENT, "abc123def"},
+		{token.ASSIGN, "="},
+		{token.INT, "42"},
+		{token.SEMICOLON, ";"},
+		{token.INT, "123"},
+		{token.SEMICOLON, ";"},
+		{token.FLOAT, "3.14"},
+		{token.SEMICOLON, ";"},
+		{token.EOF, ""},
+	}
+
+	l := New(input)
+
+	for i, tt := range tests {
 		tok := l.NextToken()
 
 		if tok.Type != tt.expectedType {


### PR DESCRIPTION
This pull request improves the handling of identifiers that contain digits in the lexer, adds corresponding tests, and introduces a new example demonstrating regular expression usage. The main changes are grouped below:

**Lexer Improvements:**

* Updated the `readIdentifier` method in `lexer/lexer.go` to allow digits within identifiers, so variable names like `var2name` and `abc123def` are now correctly recognized as identifiers.

**Testing Enhancements:**

* Added a new test `TestIdentifiersWithDigits` in `lexer/lexer_test.go` to verify that identifiers containing digits are properly tokenized. The test checks various cases such as `text1`, `var2name`, `_x3`, and `abc123def`.

**Examples and Documentation:**

* Introduced a new example file `examples/regex.monkey` that demonstrates regular expression pattern matching, replacement, and splitting, as well as simple pattern matching in the language.